### PR TITLE
Fix terminal emulator detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3315,7 +3315,7 @@ get_term() {
         name="$(get_process_name "$parent")"
 
         case ${name// } in
-            "${SHELL/*\/}"|*"sh"|"screen"|"su"*|"newgrp") ;;
+            "${SHELL/*\/}"|*"sh"|"screen"|"su"*|"newgrp"|"hyfetch") ;;
 
             "login"*|*"Login"*|"init"|"(init)")
                 term="$(tty)"


### PR DESCRIPTION
Adds `hyfetch` to the list of ignored process names when retrieving the terminal emulator.

> Terminal detection works by recursively checking parent processes until the result isn't `$SHELL`, `*sh`, `screen` or `tmux`. [[1]](https://github.com/dylanaraps/neofetch/wiki/Terminal-and-Terminal-Font-detection#all-other-os)