### PR TITLE
Add a new workflow

### DIFF
--- a/.github/workflows/arch_package.yml
+++ b/.github/workflows/arch_package.yml
@@ -1,0 +1,68 @@
+name: arch_package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux
+      options: --privileged
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+
+    steps:
+    - name: Prepare environment
+      run:  |
+            pacman -Syu --needed --noconfirm base-devel git openssh
+            sed -i '/E_ROOT/d' /usr/bin/makepkg
+
+    - name: Import AUR key
+      run:  |
+            mkdir ~/.ssh && chmod 700 ~/.ssh
+            echo '${{secrets.AUR_SSH_PRIVATE_KEY}}' >> ~/.ssh/id_rsa
+            chmod 600 ~/.ssh/id_rsa
+            ssh-keyscan -H aur.archlinux.org >> /etc/ssh/ssh_known_hosts
+
+    - name: Clone from AUR
+      run:  |
+            export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa'
+            git clone ssh://aur@aur.archlinux.org/hyfetch.git
+
+    - name: Upgrade PKGBUILD
+      run:  |
+            cd hyfetch
+            sed -i "/^pkgver=/cpkgver=${{github.ref_name}}" PKGBUILD
+            sed -i "/^pkgrel=/cpkgrel=1" PKGBUILD
+
+    - name: Makepkg
+      run:  |
+            cd hyfetch
+            yes | makepkg -si
+
+    - name: Test hyfetch
+      run:  |
+            hyfetch --test-print
+
+    - name: Upload binaries to release
+      uses: shogo82148/actions-upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: hyfetch/hyfetch*.pkg.tar.*
+
+    - name: set git info
+      run:  |
+            git config --global user.name "Aleksana QwQ"
+            git config --global user.email "me@aleksana.moe"
+
+    - name: Update PKGBUILD to AUR
+      run:  |
+            cd hyfetch
+            rm -r .SRCINFO && makepkg --srcinfo >.SRCINFO
+            git stage . && git commit -m "BOT: upgrade to ${{github.ref_name}}"
+            export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa'
+            git push
+
+

--- a/.github/workflows/arch_package.yml
+++ b/.github/workflows/arch_package.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Prepare environment
       run:  |
             pacman -Syu --needed --noconfirm base-devel git openssh
-            sed -i '/E_ROOT/d' /usr/bin/makepkg
+            useradd buildbot
 
     - name: Import AUR key
       run:  |
@@ -40,11 +40,11 @@ jobs:
     - name: Makepkg
       run:  |
             cd hyfetch
-            yes | makepkg -si
+            su buildbot -c "yes | makepkg -si"
 
     - name: Test hyfetch
       run:  |
-            hyfetch --test-print
+            su buildbot -c "hyfetch --test-print"
 
     - name: Upload binaries to release
       uses: shogo82148/actions-upload-release-asset@v1

--- a/.github/workflows/arch_package.yml
+++ b/.github/workflows/arch_package.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: set git info
       run:  |
-            git config --global user.name "Aleksana QwQ"
+            git config --global user.name "Aleksana BOT"
             git config --global user.email "me@aleksana.moe"
 
     - name: Update PKGBUILD to AUR


### PR DESCRIPTION
## Description

Added a new workflow to automatically build, test and release Arch Linux packages and PKGBUILDs.
**Please review carefully and ask as many questions as possible before merge!**

## Features

When a new release is published, the workflow will: 

- clone PKGBUILD repo from AUR, 
- update pkgver, 
- build and test (just make sure it runs) packages, 
- attach the package file to the release (not making a new one and not overriding it, just add a file),
- upload modified PKGBUILD to AUR

# Issues

The ssh in this container doesn't read `~/.ssh` and `$HOME/.ssh`, and I haven't figured out why (not because of permissions).    
So I wrote known hosts to `/etc/ssh/ssh_known_hosts` and `export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa'`    

## TODO

1. You need to add the SSH private key to secrets, the name of which is `AUR_SSH_PRIVATE_KEY`
2. I've tested "Upload binaries to release" and all previous steps and made sure they run well. The later steps has not been fully tested, because it doesn't seem to be right to make a bad commit to AUR.