### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,13 @@ jobs:
 
       - name: Merge branch and push
         run: |
-              git checkout master
+              parent=$(git show-branch \
+                      | grep -F '*' \
+                      | grep -v "$(git rev-parse --abbrev-ref HEAD)" \
+                      | head -n1 \
+                      | sed 's/.*\[\(.*\)\].*/\1/' \
+                      | sed 's/[\^~].*//')
+              git checkout ${parent}
               git merge release/${{ env.BUILDVER }} --allow-unrelated-histories
               git pull && git push && git push --tags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: release
+on:
+  push:
+    branches:
+      - "release/*"
+
+jobs:
+  testing:
+    name: testing release
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.event.head_commit.message,'release') }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Get tags
+        run: git fetch --all --tags
+
+      - name: Get version
+        run: |
+              BRANCH=$(git symbolic-ref --short HEAD)
+              VER=${BRANCH#*release/}
+              if [[ $(git tag | grep ${VER}rc) ]];then
+                TAGS=$(git tag | grep ${VER}rc | awk 'END {print}')
+                REL=${TAGS##*rc}
+                let REL++
+              else
+                REL=1
+              fi
+              echo "BUILDVER=${VER}rc${REL}" >> $GITHUB_ENV
+
+      - name: Update versions
+        run: |
+              sed -i "/^ *VERSION = /cVERSION = '${{ env.BUILDVER }}'" hyfetch/constants.py
+
+      - name: Making tags
+        run: |
+              git config user.name github-actions
+              git config user.email github-actions@github.com
+              git stage .
+              git commit -m "tagged unstable ${{ env.BUILDVER }}"
+              git tag --force ${{ env.BUILDVER }}
+
+      - name: Upload changes
+        run: |
+              git pull && git push && git push --tags
+
+      - name: Deploy to PYPI
+        uses: casperdcl/deploy-pypi@v2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          pip: wheel -w dist/ --no-deps .
+
+  release:
+    name: formal release
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.event.head_commit.message,'release') }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        run: |
+              BRANCH=$(git symbolic-ref --short HEAD)
+              echo "BUILDVER=${BRANCH#*release/}" >> $GITHUB_ENV
+
+      - name: Update package.json
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: package.json
+          field: version
+          value: ${{ env.BUILDVER }}
+
+      - name: Update neofetch version
+        run: |
+              REVISION=$(expr $(git rev-list --count HEAD neofetch) - 2902)
+              sed -i "/^ *version=/cversion=7.4.0r${REVISION}" neofetch
+
+      - name: Update other versions
+        run: |
+              sed -i "/^ *VERSION = /cVERSION = '${{ env.BUILDVER }}'" hyfetch/constants.py
+              sed -i "/^ *### Unpublished/c### ${{ env.BUILDVER }}" README.md
+
+      - name: Make final tags
+        run: |
+              git config user.name github-actions
+              git config user.email github-actions@github.com
+              git stage . && git commit -m "tagged stable ${{ env.BUILDVER }}"
+              git tag --force ${{ env.BUILDVER }}
+
+      - name: Merge branch and push
+        run: |
+              git checkout master
+              git merge release/${{ env.BUILDVER }} --allow-unrelated-histories
+              git pull && git push && git push --tags
+
+      - name: Generate changelog from README
+        run: (sed '0,/^ *### ${{ env.BUILDVER }}/d;/^ *#/,$d' <README.md)>temp_CHANGELOG.md
+
+      - name: Publish release
+        uses: ncipollo/release-action@v1
+        with:
+          bodyFile: "temp_CHANGELOG.md"
+          tag: ${{ env.BUILDVER }}
+          token: ${{ secrets.GITHUB_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
                       | sed 's/[\^~].*//')
               git checkout ${parent}
               git merge release/${{ env.BUILDVER }} --allow-unrelated-histories
-              git pull && git push && git push --tags
+              git pull --all && git push --all && git push --tags
 
       - name: Generate changelog from README
         run: (sed '0,/^ *### ${{ env.BUILDVER }}/d;/^ *#/,$d' <README.md)>temp_CHANGELOG.md


### PR DESCRIPTION
## Description

This workflow manages releases cycle and releavant version in files.

## Features

Let's start with adding a new release, i.e. `1.5.0` . Firstly, you need to create a new branch, named `release/1.5.0`
```
git branch release/1.5.0
```
Make some changes, or if you do not do anything (`--allow-empty` means you don't have to make changes), just issue
```
git commit -m "..." --allow-empty
```
Then push to GitHub
```
git push -u origin release/1.5.0
```
Now this workflow will run, 

- pull from this branch, 
- edit version in `hyfetch/constants.py`, 
- make tags on version,
- commit and push to repo,
- deploy to PYPI as prerelease.

When running first time it will set version to `1.5.0rc1` . And if you don't get satisfied with this prerelease, you can edit this branch locally, and commit again. Once the second push is done, it will run again with version set to `1.5.0rc2` , and do the work above.

After you've made all tests and believe it's ready for release,change something or not, and make a commit with message start with `release` . For example:
```
git commit -m "release: foo" --allow-empty
``` 
This workflow will run again and

- pull from this branch,
- edit version in `hyfetch/constants.py` , `package.json` and `neofetch`
- edit README.md and change head starts with `### Unpublished` to `### 1.5.0`
- merge changes into parent branch (where this branch is created),
- use contents below `###  1.5.0` to be the release changelog,
- publish release.

## TODO

Add your PYPI api token to secrets `PYPI_API_TOKEN` and GitHub user api token to `GITHUB_API_TOKEN`