### PR TITLE
Surround macOS build number in parentheses

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1275,7 +1275,7 @@ get_distro() {
                 *)      codename=macOS ;;
             esac
 
-            distro="$codename $osx_version $osx_build"
+            distro="$codename $osx_version ($osx_build)"
 
             case $distro_shorthand in
                 on) distro=${distro/ ${osx_build}} ;;


### PR DESCRIPTION
## Description

Build numbers on macOS are nearly always surrounded in parentheses.
IMO it makes sense to do it here as well.