### PR TITLE
Fixed bug identifying WM as DE

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2210,9 +2210,8 @@ get_wm() {
         *)         ps_flags=(-e) ;;
     esac
 
-    if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]]; then
-        if tmp_pid="$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)" ||
-           tmp_pid="$(fuser   "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)"; then
+    if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]] || [[ -x "$(which lsof 2>/dev/null)" ]]; then
+        if tmp_pid="$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)"; then
             wm="$(ps -p "${tmp_pid}" -ho comm=)"
         else
             # lsof may not exist, or may need root on some systems. Similarly fuser.

--- a/neofetch
+++ b/neofetch
@@ -2210,7 +2210,7 @@ get_wm() {
         *)         ps_flags=(-e) ;;
     esac
 
-    if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]] || [[ -x "$(which lsof 2>/dev/null)" ]]; then
+    if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]] && [[ -x "$(which lsof 2>/dev/null)" ]]; then
         if tmp_pid="$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)"; then
             wm="$(ps -p "${tmp_pid}" -ho comm=)"
         else


### PR DESCRIPTION


## Description

When `lsof` is not found, due to script logic errors,  WM such as `hyprland` may be incorrectly identified as  DE and reproduced in the gentoo system


## Features

fixed bug

## Issues

When `lsof` is not found, due to script logic errors,  WM such as `hyprland` may be incorrectly identified as  DE and reproduced in the gentoo system
