### PR TITLE
fix: assume no pkgs when dir is empty or does not exist

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1807,7 +1807,7 @@ get_packages() {
     has() { type -p "$1" >/dev/null && manager=$1; }
     # globbing is intentional here
     # shellcheck disable=SC2206
-    dir() { pkgs=($@); ((packages+=${#pkgs[@]})); pac "$((${#pkgs[@]}-pkgs_h))"; }
+    dir() { pkgs=($@); [[ ! -e ${pkgs[0]} ]] && return; ((packages+=${#pkgs[@]})); pac "$((${#pkgs[@]}-pkgs_h))"; }
     pac() { (($1 > 0)) && { managers+=("$1 (${manager})"); manager_string+="${manager}, "; }; }
     tot() {
         IFS=$'\n' read -d "" -ra pkgs <<< "$("$@")";


### PR DESCRIPTION
## Description

I have `cargo` installed but do not have any packages installed with `cargo`. Because it is installed, it does a check anyway for the number of files in `~/.cargo/bin/*`, which does not exist for me and so is not expanded by bash and looks like one entry: a literal `~/.cargo/bin/*` (which also happens if the directory exists but is empty)

This causes neofetch to erroneously report that I have 1 `cargo` package installed when there is none (see output below)

This PR fixes this by ensuring that the first element passed to the internal `dir` function exists before counting the number of arguments to get number of packages, and fixes both the case when the directory does not exist and fixes when the directory is empty

## Output

### Without Fix

<details>
<summary>No <code>~/.cargo/bin</code></summary>

```
lily@bina 
--------- 
OS: NixOS 23.05.20221229.677ed08 (Stoat) x86_64 
Host: Laptop (12th Gen Intel Core) A6 
Kernel: 6.1.1 
Uptime: 50 mins 
Packages: 5877 (nix-system), 625 (nix-user), 1 (cargo) 
Shell: fish 3.5.1 
Editor: vi NVIM v0.8.1 
Resolution: 2256x1504 
WM: sway 
Theme: Materia-Fooster [GTK2/3] 
Icons: Papirus-Dark [GTK2/3] 
Cursor: Bibata-Modern-Classic [GTK2/3] 
Terminal: alacritty 
CPU: 12th Gen Intel i7-1260P (16) @ 4.7GHz 
Memory: 3.29 GiB / 31.07 GiB (10%) 
Network: Wifi 
```
</details>

<details>
<summary>Empty <code>~/.cargo/bin</code></summary>

```
lily@bina 
--------- 
OS: NixOS 23.05.20221229.677ed08 (Stoat) x86_64 
Host: Laptop (12th Gen Intel Core) A6 
Kernel: 6.1.1 
Uptime: 50 mins 
Packages: 5877 (nix-system), 625 (nix-user), 1 (cargo) 
Shell: fish 3.5.1 
Editor: vi NVIM v0.8.1 
Resolution: 2256x1504 
WM: sway 
Theme: Materia-Fooster [GTK2/3] 
Icons: Papirus-Dark [GTK2/3] 
Cursor: Bibata-Modern-Classic [GTK2/3] 
Terminal: alacritty 
CPU: 12th Gen Intel i7-1260P (16) @ 4.7GHz 
Memory: 3.30 GiB / 31.07 GiB (10%) 
Network: Wifi 
```
</details>

<details>
<summary>One package installed to <code>~/.cargo/bin</code></summary>

```
lily@bina 
--------- 
OS: NixOS 23.05.20221229.677ed08 (Stoat) x86_64 
Host: Laptop (12th Gen Intel Core) A6 
Kernel: 6.1.1 
Uptime: 55 mins 
Packages: 5877 (nix-system), 625 (nix-user), 1 (cargo) 
Shell: fish 3.5.1 
Editor: vi NVIM v0.8.1 
Resolution: 2256x1504 
WM: sway 
Theme: Materia-Fooster [GTK2/3] 
Icons: Papirus-Dark [GTK2/3] 
Cursor: Bibata-Modern-Classic [GTK2/3] 
Terminal: alacritty 
CPU: 12th Gen Intel i7-1260P (16) @ 4.7GHz 
Memory: 3.30 GiB / 31.07 GiB (10%) 
Network: Wifi 
```
</details>

### With Fix

<details>
<summary>No <code>~/.cargo/bin</code></summary>

```
lily@bina 
--------- 
OS: NixOS 23.05.20221229.677ed08 (Stoat) x86_64 
Host: Laptop (12th Gen Intel Core) A6 
Kernel: 6.1.1 
Uptime: 52 mins 
Packages: 5877 (nix-system), 625 (nix-user) 
Shell: fish 3.5.1 
Editor: vi NVIM v0.8.1 
Resolution: 2256x1504 
WM: sway 
Theme: Materia-Fooster [GTK2/3] 
Icons: Papirus-Dark [GTK2/3] 
Cursor: Bibata-Modern-Classic [GTK2/3] 
Terminal: alacritty 
CPU: 12th Gen Intel i7-1260P (16) @ 4.7GHz 
Memory: 3.25 GiB / 31.07 GiB (10%) 
Network: Wifi 
```
</details>

<details>
<summary>Empty <code>~/.cargo/bin</code></summary>

```
lily@bina 
--------- 
OS: NixOS 23.05.20221229.677ed08 (Stoat) x86_64 
Host: Laptop (12th Gen Intel Core) A6 
Kernel: 6.1.1 
Uptime: 52 mins 
Packages: 5877 (nix-system), 625 (nix-user) 
Shell: fish 3.5.1 
Editor: vi NVIM v0.8.1 
Resolution: 2256x1504 
WM: sway 
Theme: Materia-Fooster [GTK2/3] 
Icons: Papirus-Dark [GTK2/3] 
Cursor: Bibata-Modern-Classic [GTK2/3] 
Terminal: alacritty 
CPU: 12th Gen Intel i7-1260P (16) @ 4.7GHz 
Memory: 3.30 GiB / 31.07 GiB (10%) 
Network: Wifi 
```
</details>

<details>
<summary>One package installed to <code>~/.cargo/bin</code></summary>

```
lily@bina 
--------- 
OS: NixOS 23.05.20221229.677ed08 (Stoat) x86_64 
Host: Laptop (12th Gen Intel Core) A6 
Kernel: 6.1.1 
Uptime: 53 mins 
Packages: 5877 (nix-system), 625 (nix-user), 1 (cargo) 
Shell: fish 3.5.1 
Editor: vi NVIM v0.8.1 
Resolution: 2256x1504 
WM: sway 
Theme: Materia-Fooster [GTK2/3] 
Icons: Papirus-Dark [GTK2/3] 
Cursor: Bibata-Modern-Classic [GTK2/3] 
Terminal: alacritty 
CPU: 12th Gen Intel i7-1260P (16) @ 4.7GHz 
Memory: 3.23 GiB / 31.07 GiB (10%) 
Network: Wifi 
```
</details>