### PR TITLE
Add support for displaying the ISA string on RISC-V CPUs

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2587,6 +2587,18 @@ get_cpu() {
                     [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' "$cpu_file")"
                 ;;
 
+                "riscv"* | "rv"*)
+                    cpu_uarch="$(awk -F':' '/uarch/ {print $2; exit}' "$cpu_file")"
+                    # RISC-V ISA string example: "rv64imafdch_zicsr_zifencei".
+                    cpu_isa="$(awk -F':' '/isa/ {print $2; exit}' "$cpu_file")"
+                    # The _z parts are not important for CPU showcasing, so we remove them.
+                    cpu_isa="${cpu_isa%%_*}"
+                    # Then we replace "imafd" with "g" since "g" is a shorthand.
+                    cpu_isa="${cpu_isa/imafd/g}"
+                    # The final ISA output of the above example is "rv64gch".
+                    cpu="$cpu_uarch $cpu_isa"
+                ;;
+
                 "arm"* | "aarch64")
                     if [[ $(trim "$distro") == Android* ]]; then
                         # Android roms have modified cpuinfo that shows CPU model as a string


### PR DESCRIPTION
## Description

This PR adds support for displaying the ISA string (like "rv64gc") in the CPU section on RISC-V CPUs.

I have tested this both on real hardware (Debian on StarFive VisionFive 2) and an emulator (Ubuntu on Qemu).

Example output on real hardware (Debian on StarFive VisionFive 2):

```
$ ./runner.py 
                                   user@starfive 
       _,met$$$$$gg.               ------------- 
    ,g$$$$$$$$$$$$$$$P.            OS: Debian GNU/Linux bookworm/sid riscv64 
  ,g$$P"        \"""Y$$.".         Host: StarFive VisionFive V2 
 ,$$P'              `$$$.          Kernel: 5.15.0-starfive 
',$$P       ,ggs.     `$$b:        Uptime: 1 hour, 42 mins 
`d$$'     ,$P"'   .    $$$         Packages: 1883 (dpkg), 15 (cargo) 
 $$P      d$'     ,    $$P         Shell: bash 5.1.16 
 $$:      $$.   -    ,d$$'         Resolution: 3840x2160 
 $$;      Y$b._   _,d$P'           Terminal: /dev/pts/1 
 Y$$.    `.`"Y$$$$P"'              CPU: sifive,u74-mc rv64gc (4) @ 1.500GHz 
 `$$b      "-.__                   Memory: 650.87 MiB / 7927.83 MiB 
  `Y$$                     
   `Y$$.                                                   
     `$$b.                                                 
       `Y$$b.              
          `"Y$b._          
              `\"""        
```

Example output on the emulator (Ubuntu 20.04 on Qemu):

```
$ ./runner.py 
                                              ubuntu@ubuntu 
                             ....             ------------- 
              .',:clooo:  .:looooo:.          OS: Ubuntu 20.04.2 LTS riscv64 
           .;looooooooc  .oooooooooo'         Host: riscv-virtio,qemu 
        .;looooool:,''.  :ooooooooooc         Kernel: 5.8.0-14-generic 
       ;looool;.         'oooooooooo,         Uptime: 44 mins 
      ;clool'             .cooooooc.  ,,      Packages: 760 (dpkg) 
         ...                ......  .:oo,     Shell: bash 5.0.17 
  .;clol:,.                        .loooo'    Terminal: /dev/pts/0 
 :ooooooooo,                        'ooool    CPU: rv64gch (8) 
'ooooooooooo.                        loooo.   Memory: 0.34 GiB / 15.62 GiB (2%) 
'ooooooooool                         coooo.   Network: Unknown 
 ,loooooooc.                        .loooo.
   .,;;;'.                          ;ooooc                            
       ...                         ,ooool.                            
    .cooooc.              ..',,'.  .cooo.  
      ;ooooo:.           ;oooooooc.  :l.   
       .coooooc,..      coooooooooo.       
         .:ooooooolc:. .ooooooooooo'       
           .':loooooo;  ,oooooooooc        
               ..';::c'  .;loooo:'         
                             .
```

For comparison, here is what the output looks like in hyfetch before this PR:

<details>
Old/existing output on real hardware (Debian on StarFive VisionFive 2):

```
$ hyfetch 
                                   user@starfive 
       _,met$$$$$gg.               ------------- 
    ,g$$$$$$$$$$$$$$$P.            OS: Debian GNU/Linux bookworm/sid riscv64 
  ,g$$P"        \"""Y$$.".         Host: StarFive VisionFive V2 
 ,$$P'              `$$$.          Kernel: 5.15.0-starfive 
',$$P       ,ggs.     `$$b:        Uptime: 1 hour, 42 mins 
`d$$'     ,$P"'   .    $$$         Packages: 1883 (dpkg), 15 (cargo) 
 $$P      d$'     ,    $$P         Shell: bash 5.1.16 
 $$:      $$.   -    ,d$$'         Resolution: 3840x2160 
 $$;      Y$b._   _,d$P'           Terminal: /dev/pts/1 
 Y$$.    `.`"Y$$$$P"'              CPU: sifive,u74-mc (4) @ 1.500GHz
 `$$b      "-.__                   Memory: 650.87 MiB / 7927.83 MiB 
  `Y$$                     
   `Y$$.                                                   
     `$$b.                                                 
       `Y$$b.              
          `"Y$b._          
              `\"""        
```

Old/existing output on the emulator (Ubuntu 20.04 on Qemu):

```
$ hyfetch 
                                              ubuntu@ubuntu 
                             ....             ------------- 
              .',:clooo:  .:looooo:.          OS: Ubuntu 20.04.2 LTS riscv64 
           .;looooooooc  .oooooooooo'         Host: riscv-virtio,qemu 
        .;looooool:,''.  :ooooooooooc         Kernel: 5.8.0-14-generic 
       ;looool;.         'oooooooooo,         Uptime: 44 mins 
      ;clool'             .cooooooc.  ,,      Packages: 760 (dpkg) 
         ...                ......  .:oo,     Shell: bash 5.0.17 
  .;clol:,.                        .loooo'    Terminal: /dev/pts/0 
 :ooooooooo,                        'ooool    CPU: (8) 
'ooooooooooo.                        loooo.   Memory: 0.34 GiB / 15.62 GiB (2%) 
'ooooooooool                         coooo.   Network: Unknown 
 ,loooooooc.                        .loooo.
   .,;;;'.                          ;ooooc                            
       ...                         ,ooool.                            
    .cooooc.              ..',,'.  .cooo.  
      ;ooooo:.           ;oooooooc.  :l.   
       .coooooc,..      coooooooooo.       
         .:ooooooolc:. .ooooooooooo'       
           .':loooooo;  ,oooooooooc        
               ..';::c'  .;loooo:'         
                             .
```
</details>

