### PR TITLE
fix: fix fastfetch raw mode

### DIFF
--- a/hyfetch/neofetch_util.py
+++ b/hyfetch/neofetch_util.py
@@ -307,7 +307,7 @@ def run_fastfetch(preset: ColorProfile, alignment: ColorAlignment):
         path.write_text(asc)
 
         # Call fastfetch with the temp file
-        subprocess.run(['fastfetch', '--raw', path.absolute()])
+        subprocess.run(['fastfetch', '--file-raw', path.absolute()])
 
 
 def get_fore_back(distro: str | None = None) -> tuple[int, int] | None:


### PR DESCRIPTION
## Description
With fastfetch v1.8.2, attempting to use the fastfetch backend results in this error.
```
$ hyfetch -b fastfetch
Error: unknown option: --raw
```

This PR fixes the issue by changing the ``--raw`` option to ``--file-raw``.