### PR TITLE
Fix git path being hard-coded This enables running hyfetch on machine…

### DIFF
--- a/hyfetch/neofetch_util.py
+++ b/hyfetch/neofetch_util.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import sys
 import zipfile
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import check_output
@@ -150,7 +151,6 @@ def get_command_path() -> str:
 
     return cmd_path
 
-
 def ensure_git_bash() -> Path:
     """
     Ensure git bash installation for windows
@@ -162,6 +162,17 @@ def ensure_git_bash() -> Path:
         def_path = Path(r'C:\Program Files\Git\bin\bash.exe')
         if def_path.is_file():
             return def_path
+
+        # Labda expression that finds out if a command exists
+        cmd_exists = lambda x: shutil.which(x) is not None
+
+        # TEMP-FIX: Make git not hard-coded to being installed "officially" via the git-for-windows installer
+        if ( cmd_exists("git.exe") ):
+            pth = Path(shutil.which("git")).parent
+            if(os.path.isfile(pth / r'bash.exe')):
+                return pth / r'bash.exe'
+            elif ( os.path.isfile(pth / r'/bin/bash.exe')):
+                return pth / r'/bin/bash.exe'
 
         # Find installation in PATH (C:\Program Files\Git\cmd should be in path)
         pth = (os.environ.get('PATH') or '').lower().split(';')


### PR DESCRIPTION
Fixed git being hard-coded to being installed with the git-for-windows installer.

## Description

Now no longer requires git to be installed to "program files". Now picks up git installed via `scoop` and will use bash from the scoop version of git

## Features

Now no longer needs administrator to install, (git-for-windows needs administrator)

## Issues

Not yet tested with the git-for-windows version of git, But confirmed working with scoop version of git.

## TODO
