### PR TITLE
Fix git check for windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Module",
+            "type": "python",
+            "request": "launch",
+            "module": "hyfetch",
+            "justMyCode": true
+        }
+    ]
+}

--- a/hyfetch/neofetch_util.py
+++ b/hyfetch/neofetch_util.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import sys
 import zipfile
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import check_output
@@ -150,7 +151,6 @@ def get_command_path() -> str:
 
     return cmd_path
 
-
 def ensure_git_bash() -> Path:
     """
     Ensure git bash installation for windows
@@ -162,6 +162,17 @@ def ensure_git_bash() -> Path:
         def_path = Path(r'C:\Program Files\Git\bin\bash.exe')
         if def_path.is_file():
             return def_path
+
+        # Labda expression that finds out if a command exists
+        cmd_exists = lambda x: shutil.which(x) is not None
+
+        # TEMP-FIX: Make git not hard-coded to being installed "officially" via the git-for-windows installer
+        if ( cmd_exists("git.exe") ):
+            pth = Path(shutil.which("git")).parent
+            if(os.path.isfile(pth / r'bash.exe')):
+                return pth / r'bash.exe'
+            elif ( os.path.isfile(pth / r'/bin/bash.exe')):
+                return pth / r'/bin/bash.exe'
 
         # Find installation in PATH (C:\Program Files\Git\cmd should be in path)
         pth = (os.environ.get('PATH') or '').lower().split(';')


### PR DESCRIPTION
## Description

Fix git path being hard-coded on windows.
Also added a vs-code debugging profile for others to not go in the same route as me: trying to debug while vscode's debugger runs everything from the wrong directory.


## Features

Disable HyFetch's requirement of git installed from the "GitForWindows" website. (https://gitforwindows.org/)

## Issues

None AFAIK, Don't know if this works with the GitForWindows version of git yet, but i assume it does due to my un-obtrusive code additions.

## TODO

Verify compatibility with GitForWindows.