### PR TITLE
fix: swaybg causing sway false positives

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2323,7 +2323,7 @@ get_wm() {
                                -e perceptia \
                                -e river \
                                -e rustland \
-                               -e sway \
+                               -e sway$ \
                                -e ulubis \
                                -e velox \
                                -e wavy \


### PR DESCRIPTION
## Description
Many  wlroots based WMs use swaybg to set the background. Which does occasionally cause false positives (detection of sway as a WM when it's actually not the case).

## Issues
This fixes sway being shown when the current WM is not sway (in case swaybg is running).