### PR TITLE
Better colour/formatting codes

### DIFF
--- a/hyfetch/color_util.py
+++ b/hyfetch/color_util.py
@@ -6,11 +6,33 @@ from dataclasses import dataclass, astuple
 from .constants import GLOBAL_CFG
 from .types import *
 
-MINECRAFT_COLORS = ["&0/\033[0;30m", "&1/\033[0;34m", "&2/\033[0;32m", "&3/\033[0;36m", "&4/\033[0;31m",
-                    "&5/\033[0;35m", "&6/\033[0;33m", "&7/\033[0;37m", "&8/\033[1;30m", "&9/\033[1;34m",
-                    "&a/\033[1;32m", "&b/\033[1;36m", "&c/\033[1;31m", "&d/\033[1;35m", "&e/\033[1;33m",
-                    "&f/\033[1;37m",
-                    "&r/\033[0m", "&l/\033[1m", "&o/\033[3m", "&n/\033[4m", "&-/\n"]
+MINECRAFT_COLORS = [
+
+    # Minecraft formatting codes
+    # ==========================
+    "&0/\033[38;5;0m", "&1/\033[38;5;4m",  "&2/\033[38;5;2m",  "&3/\033[38;5;6m",
+    "&4/\033[38;5;1m", "&5/\033[38;5;5m",  "&6/\033[38;5;3m",  "&7/\033[38;5;7m",
+    "&8/\033[38;5;8m", "&9/\033[38;5;12m", "&a/\033[38;5;10m", "&b/\033[38;5;14m",
+    "&c/\033[38;5;9m", "&d/\033[38;5;13m", "&e/\033[38;5;11m", "&f/\033[38;5;15m",
+    "&l/\033[1m",   # Enable bold text
+    "&o/\033[3m",   # Enable italic text
+    "&n/\033[4m",   # Enable underlined text
+    "&k/\033[8m",   # Enable hidden text
+    "&m/\033[9m",   # Enable strikethrough text
+    "&r/\033[0m",   # Reset everything
+
+    # Extended codes (not officially in Minecraft)
+    # ============================================
+    "&-/\n",        # Line break
+    "&~/\033[39m",  # Reset text color
+    "&*/\033[49m",  # Reset background color
+    "&L/\033[22m",  # Disable bold text
+    "&O/\033[23m",  # Disable italic text
+    "&N/\033[24m",  # Disable underlined text
+    "&K/\033[28m",  # Disable hidden text
+    "&M/\033[29m",  # Disable strikethrough text
+
+]
 MINECRAFT_COLORS = [(r[:2], r[3:]) for r in MINECRAFT_COLORS]
 
 

--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -44,7 +44,7 @@ def create_config() -> Config:
 
     asc = get_distro_ascii()
     asc_width, asc_lines = ascii_size(asc)
-    logo = color("&b&lhyfetch&r" if det_bg is None or det_bg.is_light() else "&b&lhy&f&lfetch&r")
+    logo = color("&l&bhyfetch&~&L" if det_bg is None or det_bg.is_light() else "&l&bhy&ffetch&~&L")
     title = f'Welcome to {logo} Let\'s set up some colors first.'
     clear_screen(title)
 
@@ -54,7 +54,7 @@ def create_config() -> Config:
         nonlocal title, option_counter
         if not k.endswith(":"):
             k += ':'
-        title += f"\n&e{option_counter}. {k.ljust(30)} &r{v}"
+        title += f"\n&e{option_counter}. {k.ljust(30)} &~{v}"
         option_counter += 1
 
     def print_title_prompt(prompt: str):
@@ -107,7 +107,7 @@ def create_config() -> Config:
             return det_bg.is_light(), 'Detected background color'
 
         clear_screen(title)
-        inp = literal_input(f'2. Is your terminal in &blight mode&r or &4dark mode&r?',
+        inp = literal_input(f'2. Is your terminal in &blight mode&~ or &4dark mode&~?',
                             ['light', 'dark'], 'dark')
         return inp == 'light', 'Selected background color'
 
@@ -308,7 +308,7 @@ def run():
         colorama.just_fix_windows_console()
 
     # Create CLI
-    hyfetch = color('&b&lhyfetch&r')
+    hyfetch = color('&l&bhyfetch&~&L')
     parser = argparse.ArgumentParser(description=color(f'{hyfetch} - neofetch with flags <3'))
 
     parser.add_argument('-c', '--config', action='store_true', help=color(f'Configure {hyfetch}'))

--- a/hyfetch/neofetch_util.py
+++ b/hyfetch/neofetch_util.py
@@ -39,7 +39,7 @@ def literal_input(prompt: str, options: Iterable[str], default: str, show_ops: b
     lows = [o.lower() for o in options]
 
     if show_ops:
-        op_text = '|'.join([f'&l&n{o}&r' if o == default else o for o in options])
+        op_text = '|'.join([f'&l&n{o}&L&N' if o == default else o for o in options])
         printc(f'{prompt} ({op_text})')
     else:
         printc(f'{prompt} (default: {default})')
@@ -149,7 +149,7 @@ class ColorAlignment:
             # Add new colors
             if self.mode == 'horizontal':
                 colors = preset.with_length(len(lines))
-                asc = '\n'.join([l.replace(f'${{c{back}}}', colors[i].to_ansi()) + color('&r') for i, l in enumerate(lines)])
+                asc = '\n'.join([l.replace(f'${{c{back}}}', colors[i].to_ansi()) + color('&~&*') for i, l in enumerate(lines)])
             else:
                 raise NotImplementedError()
 
@@ -164,9 +164,9 @@ class ColorAlignment:
             # Add new colors
             if self.mode == 'horizontal':
                 colors = preset.with_length(len(lines))
-                asc = '\n'.join([colors[i].to_ansi() + l + color('&r') for i, l in enumerate(lines)])
+                asc = '\n'.join([colors[i].to_ansi() + l + color('&~&*') for i, l in enumerate(lines)])
             else:
-                asc = '\n'.join(preset.color_text(line) + color('&r') for line in lines)
+                asc = '\n'.join(preset.color_text(line) + color('&~&*') for line in lines)
 
         else:
             preset = preset.unique_colors()

--- a/hyfetch/presets.py
+++ b/hyfetch/presets.py
@@ -83,12 +83,12 @@ class ColorProfile:
         for i, t in enumerate(txt):
             if space_only and t != ' ':
                 if i > 0 and txt[i - 1] == ' ':
-                    result += '\033[0m'
+                    result += '\033[39;49m'
                 result += t
             else:
                 result += colors[i].to_ansi(foreground=foreground) + t
 
-        result += '\033[0m'
+        result += '\033[39;49m'
         return result
 
     def lighten(self, multiplier: float) -> ColorProfile:

--- a/neofetch
+++ b/neofetch
@@ -38,7 +38,7 @@ shopt -s eval_unsafe_arith &>/dev/null
 sys_locale=${LANG:-C}
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME}/.config}
 PATH=$PATH:/usr/xpg4/bin:/usr/sbin:/sbin:/usr/etc:/usr/libexec
-reset='\e[0m'
+reset='\e[39;22m'
 shopt -s nocasematch extglob
 
 # Speed up script by not using unicode.
@@ -4805,16 +4805,19 @@ get_cols() {
             esac
         done
 
+        # Workaround for bright background colors in the Linux framebuffer console.
+        (( block_range[1] < 16 )) && printf -v blocks2 '\e[5m%b\e[25m' "$blocks2"
+
         # Convert height into spaces.
         printf -v block_spaces "%${block_height}s"
 
         # Convert the spaces into rows of blocks.
         if [[ $BASH_VERSION == 3* ]]; then
-            [[ "$blocks"  ]] && cols+="${block_spaces// /${blocks}[mnl}"
-            [[ "$blocks2" ]] && cols+="${block_spaces// /${blocks2}[mnl}"
+            [[ "$blocks"  ]] && cols+="${block_spaces// /${blocks}[39;49mnl}"
+            [[ "$blocks2" ]] && cols+="${block_spaces// /${blocks2}[39;49mnl}"
         else
-            [[ "$blocks"  ]] && cols+="${block_spaces// /${blocks}\[mnl}"
-            [[ "$blocks2" ]] && cols+="${block_spaces// /${blocks2}\[mnl}"
+            [[ "$blocks"  ]] && cols+="${block_spaces// /${blocks}\[39;49mnl}"
+            [[ "$blocks2" ]] && cols+="${block_spaces// /${blocks2}\[39;49mnl}"
         fi
 
         # Determine the horizontal offset of the blocks.
@@ -5529,12 +5532,8 @@ trim_quotes() {
 }
 
 strip_sequences() {
-    strip="${1//$'\e['3[0-9]m}"
-    strip="${strip//$'\e['[0-9]m}"
-    strip="${strip//\\e\[[0-9]m}"
-    strip="${strip//$'\e['38\;5\;[0-9]m}"
-    strip="${strip//$'\e['38\;5\;[0-9][0-9]m}"
-    strip="${strip//$'\e['38\;5\;[0-9][0-9][0-9]m}"
+    strip="${1//$'\e'\[*([0-9])*(;*([0-9]))m}"
+    strip="${strip//\\e\[*([0-9])*(;*([0-9]))m}"
 
     printf '%s\n' "$strip"
 }
@@ -5593,8 +5592,8 @@ set_text_colors() {
 
 color() {
     case $1 in
-        [0-6])    printf '%b\e[3%sm'   "$reset" "$1" ;;
-        7 | "fg") printf '\e[37m%b'    "$reset" ;;
+        [0-7]) printf '%b\e[3%sm'   "$reset" "$1" ;;
+        "fg")  printf '%b'          "$reset" ;;
         "#"*)
             local rgb="${1//#}"
             rgb="$((0x$rgb))"

--- a/neofetch
+++ b/neofetch
@@ -4806,7 +4806,8 @@ get_cols() {
         done
 
         # Workaround for bright background colors in the Linux framebuffer console.
-        (( block_range[1] < 16 )) && printf -v blocks2 '\e[5m%b\e[25m' "$blocks2"
+        (( block_range[1] < 16 )) && [[ "$TERM" == "linux" ]] &&
+        printf -v blocks2 '\e[5m%b\e[25m' "$blocks2"
 
         # Convert height into spaces.
         printf -v block_spaces "%${block_height}s"

--- a/tools/colors_test.py
+++ b/tools/colors_test.py
@@ -25,12 +25,12 @@ def test_rgb_8bit_conversion():
     for r in range(0, 255, 16):
         for g in range(0, 255, 16):
             print(RGB(r, g, 0).to_ansi_rgb(False), end=' ')
-        printc('&r')
+        printc('&*')
     print()
     for r in range(0, 255, 16):
         for g in range(0, 255, 16):
             print(RGB(r, g, 0).to_ansi_8bit(False), end=' ')
-        printc('&r')
+        printc('&*')
     print()
 
 


### PR DESCRIPTION
Neofetch changes:
* The `color` function distinguishes between `7` and `fg` properly (`7` = white, `fg` = default foreground colour).
* The `strip_sequences` function captures ANSI SGR escape codes more accurately.
* The `reset` variable only resets the text colour and whether the text is bold or not, and doesn't reset anything else.
* Added a workaround for showing bright colour blocks (8-15) in the Linux framebuffer console, by using the blinking text attribute (`\e[5m`).

Hyfetch changes:
* Changed the Minecraft colour codes so that the dark ones don't reset anything, and the bright ones don't make the text bold.
* Added the remaining Minecraft formatting codes.
* Added extended formatting codes that reset specific things (e.g. colour, bold, italic) instead of everything.
* Changed a bunch of "reset everything" (`&r`) codes in strings, to only reset the attributes they need to.

I tested everything as much as I could, but I might have missed some stuff. Feel free to let me know if there are any problems!