### PR TITLE
Update the installation instructions for Arch Linux in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install hyfetch
 
 Currently, these distributions have existing packages for HyFetch:
 
-* Arch Linux: `paru -S hyfetch` or `yay -S hyfetch` (Thanks to [@Aleksana](https://github.com/Aleksanaa))
+* Arch Linux: `sudo pacman -S hyfetch` (Thanks to [@Aleksana](https://github.com/Aleksanaa) and [@Antiz96](https://github.com/Antiz96))
 * Nix: `nix-env -i hyfetch` (Thanks to [@YisuiDenghua](https://github.com/YisuiDenghua))
 * Guix: `guix install hyfetch` (Thanks to [@WammKD](https://github.com/WammKD))
 


### PR DESCRIPTION
Hi,

First of all, thanks a lot for your awesome work with `hyfetch`. 

I recently moved it out from the AUR to [Arch's official [community] repository](https://archlinux.org/packages/community/any/hyfetch/). That means that `hyfetch` can now be installed with `pacman` such as any other "official/regular" packages. I hope it's okay for you!
This PR aims to update the installation instruction for Arch Linux accordingly in the README.

Since I'm now the new maintainer of the `hyfetch` package on Arch's [community] repo, I allowed myself to add my GitHub nickname to the "thank to [...]" section, after Aleksana's one (which is obviously listed as a contributor in the [PKGBUILD](https://github.com/archlinux/svntogit-community/blob/packages/hyfetch/trunk/PKGBUILD) by the way). If you want me to remove it or do it differently, don't hesitate to ask for a change! :)

On a side note, I had the following warning when building the package:
```
/usr/lib/python3.10/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'hyfetch.scripts' as data is deprecated, please list it in `packages`.
    !!


    ############################
    # Package would be ignored #
    ############################
    Python recognizes 'hyfetch.scripts' as an importable package,
    but it is not listed in the `packages` configuration of setuptools.

    'hyfetch.scripts' has been automatically added to the distribution only
    because it may contain data files, but this behavior is likely to change
    in future versions of setuptools (and therefore is considered deprecated).

    Please make sure that 'hyfetch.scripts' is included as a package by using
    the `packages` configuration field or the proper discovery methods
    (for example by using `find_namespace_packages(...)`/`find_namespace:`
    instead of `find_packages(...)`/`find:`).

    You can read more about "package discovery" and "data files" on setuptools
    documentation page.


!!
```
The compilation went fine regardless and the package is totally functional but I guess it's worth noticing it in case that can be fixed.
If you want me to create a separate issue for that, don't hesitate to tell me :smiley: 

I remain available if needed :smile: 