### PR TITLE
fix cargo package count

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2054,7 +2054,7 @@ get_packages() {
             has flatpak && tot flatpak list
             has spm     && tot spm list -i
             has puyo    && dir ~/.puyo/installed
-            has cargo   && dir "${CARGO_HOME:-$HOME/.cargo}/bin/"*
+            has cargo   && _cargopkgs="$(cargo install --list | grep -v '^ ')" && tot echo "$_cargopkgs"
 
             # Snap hangs if the command is run without the daemon running.
             # Only run snap if the daemon is also running.


### PR DESCRIPTION
The cargo package count is just counting the number of files in ~/.cargo/bin, this breaks for packages that have more then one binary, or if the rust toolchain is installed with rustup

There's probably a better way of doing this that I didn't think of, but it's at least better then the old way.