### PR TITLE
Fix a typo that broke OS when running on WSL

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1277,7 +1277,8 @@ get_distro() {
 
                 windows_version_verbose=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v ProductName | grep REG_)
                 windows_version_verbose=$(trim "${windows_version_verbose/ProductName}")
-                windows_version_verbose=$(trim "${windows_version_verbose/REG_SZ}") buildnumber=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v CurrentBuildNumber | grep REG_)
+                windows_version_verbose=$(trim "${windows_version_verbose/REG_SZ}")
+                buildnumber=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v CurrentBuildNumber | grep REG_)
                 windows_version_verbose=$(trim "${windows_version_verbose/Windows}")
                 windows_buildnumber=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v CurrentBuildNumber | grep REG_)               
                 windows_buildnumber=${buildnumber/CurrentBuildNumber}

--- a/neofetch
+++ b/neofetch
@@ -1277,7 +1277,7 @@ get_distro() {
 
                 windows_version_verbose=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v ProductName | grep REG_)
                 windows_version_verbose=$(trim "${windows_version_verbose/ProductName}")
-                windows_version_verbose=$(trim "${windows_version_verbose/REG_SZ}")buildnumber=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v CurrentBuildNumber | grep REG_)
+                windows_version_verbose=$(trim "${windows_version_verbose/REG_SZ}") buildnumber=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v CurrentBuildNumber | grep REG_)
                 windows_version_verbose=$(trim "${windows_version_verbose/Windows}")
                 windows_buildnumber=$(reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -v CurrentBuildNumber | grep REG_)               
                 windows_buildnumber=${buildnumber/CurrentBuildNumber}


### PR DESCRIPTION
1st is before patch, 2nd is after patch

![Screenshot (79)](https://github.com/hykilpikonna/hyfetch/assets/57970114/d9a55e1e-1783-4640-b82d-86826aba8935)
