### PR TITLE
Add Meowix Linux logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -860,7 +860,7 @@ image_source="auto"
 # Hyperbola, iglunix, instantOS, IRIX, Itc, januslinux, Kaisen, Kali, KaOS, KDE, Kibojoe, Kogaion,
 # Korora, KrassOS, KSLinux, Kubuntu, LangitKetujuh, LaxerOS, LEDE, LibreELEC, Linspire, Linux, Linux
 # Lite, Linux Mint, Linux Mint Old, Live Raizo, LMDE, Lubuntu, Lunar, mac, Mageia, MagpieOS,
-# Mandriva, Manjaro, MassOS, MatuusOS, Maui, Mer, Minix, MIRACLE LINUX, MX, Namib, NekOS, Neptune,
+# Mandriva, Manjaro, MassOS, MatuusOS, Maui, Meowix, Mer, Minix, MIRACLE LINUX, MX, Namib, NekOS, Neptune,
 # NetBSD, Netrunner, Nitrux, NixOS, Nobara, NomadBSD, Nurunner, NuTyX, Obarun, OBRevenge, OmniOS,
 # Open Source Media Center, OpenBSD, openEuler, OpenIndiana, openmamba, OpenMandriva, OpenStage,
 # openSUSE, openSUSE Leap, openSUSE Tumbleweed, OpenWrt, OPNsense, Oracle, orchid, OS Elbrus,
@@ -6278,7 +6278,7 @@ ASCII:
                                 LangitKetujuh, LaxerOS, LEDE, LibreELEC, Linspire, Linux, Linux
                                 Lite, Linux Mint, Linux Mint Old, Live Raizo, LMDE, Lubuntu, Lunar,
                                 mac, Mageia, MagpieOS, Mandriva, Manjaro, MassOS, MatuusOS, Maui,
-                                Mer, Minix, MIRACLE LINUX, MX, Namib, NekOS, Neptune, NetBSD,
+                                Meowix, Mer, Minix, MIRACLE LINUX, MX, Namib, NekOS, Neptune, NetBSD,
                                 Netrunner, Nitrux, NixOS, Nobara, NomadBSD, Nurunner, NuTyX, Obarun,
                                 OBRevenge, OmniOS, Open Source Media Center, OpenBSD, openEuler,
                                 OpenIndiana, openmamba, OpenMandriva, OpenStage, openSUSE, openSUSE
@@ -10737,6 +10737,22 @@ ${c1}             `.-://////:--`
       `:+oooooooooooooooooooooo+:`
          .:+oooooooooooooooo+:.
              `.-://////:-.`
+EOF
+        ;;
+
+        "Meowix"*)
+            set_colors 1 3 3 4
+            read -rd '' ascii_data <<'EOF'
+${c1}         #${c2}%            ${c3}&${c4}*
+${c1}        ##${c2}%%          ${c3}&&${c4}**
+${c1}       ##  ${c2}%%        ${c3}&&  ${c4}**
+${c1}      ##    ${c2}%%      ${c3}&&    ${c4}**
+${c1}     ##      ${c2}%%    ${c3}&&      ${c4}**
+${c1}    ##        ${c2}%%  ${c3}&&        ${c4}**
+${c1}   ##          ${c2}%%${c3}&&          ${c4}**
+${c1}  ##            ${c2}%%            ${c4}**
+${c1} ##                            ${c4}**
+${c1}##                              ${c4}**
 EOF
         ;;
 


### PR DESCRIPTION
### Description
This will add the logo for Meowix Linux to `hyfetch` and `neowofetch`.

### Relevant Links
https://github.com/Meowix-Linux/Meowix-ISO - ISO build repository for Meowix Linux

### Screenshots
![Screenshot of `neowofetch` running on a live instance of Meowix](https://github.com/hykilpikonna/hyfetch/assets/37462865/e9bb7f87-39b6-43ab-a716-55b67e310b1f)

### Additional context
Meowix Linux is an Arch Linux-based distribution that heavily utilizes [Catppuccin](https://github.com/catppuccin/catppuccin).
