### PR TITLE
perf: use sed for colour removals

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -5152,7 +5152,7 @@ print_ascii() {
             strip_escape_codes "${line}" line
             # Use patterns to replace color codes that the above line did not catch
             line=${line//\\033\[*([0-9;])[JKmsu]/}
-            line=${line//\[*([0-9;])[JKmsu]/}
+            line="$(printf %b "$line" | sed -E 's/'"$(printf %b '\x1B')"'\[*[0-9;]+[JKmsu]//g')"
             ((++lines,${#line}>ascii_len)) && ascii_len="${#line}"
         done <<< "${ascii_data//\$\{??\}}"
     fi


### PR DESCRIPTION
This has a notable change of performance as the GNU `bash` interpreter's regex engine is incredibly slow.
To make this code easier to work with in the future, I've also opted to remove the `\x1B` character from the source and instead acquire it via `printf`.

This doesn't seem to have a large impact on _all_ distros, but e.g. `void` and `ubuntu` get a huge change.

Here are some example timings from before this change:

```console
$ time python3 -mhyfetch -p rainbow --distro void
                                                             mariell@mariellh-void
                        ..........                           ---------------------
                   .::::::::::::::::::..                     OS: Void Linux x86_64
               ..:::::::::::::::::::::::::.                  Host: B450M DS3H
                '::::::::::::::::::::::::::::.               Kernel: 6.3.13_1
                  ':::::''      '':::::::::::::.             Uptime: 7 hours, 53 mins
         ..         '                '':::::::::.            Packages: 626 (xbps-query)
        .||.                            ':::::::::           Shell: zsh 5.9
       .|||||.                            '::::::::          Editor: nvim NVIM v0.9.1
      .|||||||:                             ::::::::         Resolution: 3440x1440 @ 144.00Hz
      |||||||:          .::::::::.           ::::::::        WM: bspwm
 ######||||||'   ##^ v##########v::. #####  #############v   Theme: gnome [GTK2]
  ######||||| ##^ v####::::::####v::#####  #####:::::#####   Icons: Adwaita [GTK2]
   ######||##^   #####::::::#####::#####  #####:::::######   Cursor: Adwaita [GTK2]
    ######^||    #####:::::####^::#####  #####:::::#####^    Terminal: alacritty
     ##^|||||    ^###########^:::#####  ##############^      Terminal Font: monospace
      |||||||:          '::::::::'          .::::::::        CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
      '|||||||:                            .::::::::'        GPU: NVIDIA GeForce RTX 4070
       '|||||||:.                           '::::::          Memory: 11.72 GiB / 31.29 GiB (37%)
        '||||||||:.                           ':::           Network: 1 Gbps
         ':|||||||||.                .          '            Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
           '|||||||||||:...    ...:||||.                     BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)
             ':||||||||||||||||||||||||||.
                ':|||||||||||||||||||||||''
                   '':||||||||||||||:''
                          ''''''


python3 -mhyfetch -p rainbow --distro void  46.06s user 0.06s system 99% cpu 46.177 total

$ time python3 -mhyfetch -p transgender --distro void
                                                             mariell@mariellh-void
                        ..........                           ---------------------
                   .::::::::::::::::::..                     OS: Void Linux x86_64
               ..:::::::::::::::::::::::::.                  Host: B450M DS3H
                '::::::::::::::::::::::::::::.               Kernel: 6.3.13_1
                  ':::::''      '':::::::::::::.             Uptime: 7 hours, 55 mins
         ..         '                '':::::::::.            Packages: 626 (xbps-query)
        .||.                            ':::::::::           Shell: zsh 5.9
       .|||||.                            '::::::::          Editor: nvim NVIM v0.9.1
      .|||||||:                             ::::::::         Resolution: 3440x1440 @ 144.00Hz
      |||||||:          .::::::::.           ::::::::        WM: bspwm
 ######||||||'   ##^ v##########v::. #####  #############v   Theme: gnome [GTK2]
  ######||||| ##^ v####::::::####v::#####  #####:::::#####   Icons: Adwaita [GTK2]
   ######||##^   #####::::::#####::#####  #####:::::######   Cursor: Adwaita [GTK2]
    ######^||    #####:::::####^::#####  #####:::::#####^    Terminal: alacritty
     ##^|||||    ^###########^:::#####  ##############^      Terminal Font: monospace
      |||||||:          '::::::::'          .::::::::        CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
      '|||||||:                            .::::::::'        GPU: NVIDIA GeForce RTX 4070
       '|||||||:.                           '::::::          Memory: 11.70 GiB / 31.29 GiB (37%)
        '||||||||:.                           ':::           Network: 1 Gbps
         ':|||||||||.                .          '            Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
           '|||||||||||:...    ...:||||.                     BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)
             ':||||||||||||||||||||||||||.
                ':|||||||||||||||||||||||''
                   '':||||||||||||||:''
                          ''''''


python3 -mhyfetch -p transgender --distro void  50.83s user 0.07s system 99% cpu 50.962 total

$ time python3 -mhyfetch -p transgender --distro arch
                                         mariell@mariellh-void
                   -`                    ---------------------
                  .o+`                   OS: Void Linux x86_64
                 `ooo/                   Host: B450M DS3H
                `+oooo:                  Kernel: 6.3.13_1
               `+oooooo:                 Uptime: 7 hours, 55 mins
               -+oooooo+:                Packages: 626 (xbps-query)
             `/:-:++oooo+:               Shell: zsh 5.9
            `/++++/+++++++:              Editor: nvim NVIM v0.9.1
           `/++++++++++++++:             Resolution: 3440x1440 @ 144.00Hz
          `/+++ooooooooooooo/`           WM: bspwm
         ./ooosssso++osssssso+`          Theme: gnome [GTK2]
        .oossssso-````/ossssss+`         Icons: Adwaita [GTK2]
       -osssssso.      :ssssssso.        Cursor: Adwaita [GTK2]
      :osssssss/        osssso+++.       Terminal: alacritty
     /ossssssss/        +ssssooo/-       Terminal Font: monospace
   `/ossssso+/:-        -:/+osssso+-     CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
  `+sso+:-`                 `.-/+oso:    GPU: NVIDIA GeForce RTX 4070
 `++:.                           `-/+/   Memory: 11.70 GiB / 31.29 GiB (37%)
 .`                                 `/   Network: 1 Gbps
                                         Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
                                         BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)




python3 -mhyfetch -p transgender --distro arch  0.34s user 0.07s system 101% cpu 0.401 total

$ time python3 -mhyfetch -p transgender --distro ubuntu
                                              mariell@mariellh-void
                             ....             ---------------------
              .',:clooo:  .:looooo:.          OS: Void Linux x86_64
           .;looooooooc  .oooooooooo'         Host: B450M DS3H
        .;looooool:,''.  :ooooooooooc         Kernel: 6.3.13_1
       ;looool;.         'oooooooooo,         Uptime: 7 hours, 57 mins
      ;clool'             .cooooooc.  ,,      Packages: 626 (xbps-query)
         ...                ......  .:oo,     Shell: zsh 5.9
  .;clol:,.                        .loooo'    Editor: nvim NVIM v0.9.1
 :ooooooooo,                        'ooool    Resolution: 3440x1440 @ 144.00Hz
'ooooooooooo.                        loooo.   WM: bspwm
'ooooooooool                         coooo.   Theme: gnome [GTK2]
 ,loooooooc.                        .loooo.   Icons: Adwaita [GTK2]
   .,;;;'.                          ;ooooc    Cursor: Adwaita [GTK2]
       ...                         ,ooool.    Terminal: alacritty
    .cooooc.              ..',,'.  .cooo.     Terminal Font: monospace
      ;ooooo:.           ;oooooooc.  :l.      CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
       .coooooc,..      coooooooooo.          GPU: NVIDIA GeForce RTX 4070
         .:ooooooolc:. .ooooooooooo'          Memory: 11.60 GiB / 31.29 GiB (37%)
           .':loooooo;  ,oooooooooc           Network: 1 Gbps
               ..';::c'  .;loooo:'            Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
                             .                BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)




python3 -mhyfetch -p transgender --distro ubuntu  21.12s user 0.07s system 99% cpu 21.246 total

$ time python3 -mhyfetch -p transgender --distro windows10
                                      mariell@mariellh-void
                                ..,   ---------------------
                    ....,,:;+ccllll   OS: Void Linux x86_64
      ...,,+:;  cllllllllllllllllll   Host: B450M DS3H
,cclllllllllll  lllllllllllllllllll   Kernel: 6.3.13_1
llllllllllllll  lllllllllllllllllll   Uptime: 7 hours, 59 mins
llllllllllllll  lllllllllllllllllll   Packages: 626 (xbps-query)
llllllllllllll  lllllllllllllllllll   Shell: zsh 5.9
llllllllllllll  lllllllllllllllllll   Editor: nvim NVIM v0.9.1
llllllllllllll  lllllllllllllllllll   Resolution: 3440x1440 @ 144.00Hz
                                      WM: bspwm
llllllllllllll  lllllllllllllllllll   Theme: gnome [GTK2]
llllllllllllll  lllllllllllllllllll   Icons: Adwaita [GTK2]
llllllllllllll  lllllllllllllllllll   Cursor: Adwaita [GTK2]
llllllllllllll  lllllllllllllllllll   Terminal: alacritty
llllllllllllll  lllllllllllllllllll   Terminal Font: monospace
`'ccllllllllll  lllllllllllllllllll   CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
       `' \*::  :ccllllllllllllllll   GPU: NVIDIA GeForce RTX 4070
                       ````''*::cll   Memory: 11.60 GiB / 31.29 GiB (37%)
                                 ``   Network: 1 Gbps
                                      Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
                                      BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)




python3 -mhyfetch -p transgender --distro windows10  2.17s user 0.08s system 100% cpu 2.242 total
```

And here are some examples from after this change:

```console
$ time python3 -mhyfetch -p transgender --distro void
                                                             mariell@mariellh-void
                        ..........                           ---------------------
                   .::::::::::::::::::..                     OS: Void Linux x86_64
               ..:::::::::::::::::::::::::.                  Host: B450M DS3H
                '::::::::::::::::::::::::::::.               Kernel: 6.3.13_1
                  ':::::''      '':::::::::::::.             Uptime: 7 hours, 57 mins
         ..         '                '':::::::::.            Packages: 626 (xbps-query)
        .||.                            ':::::::::           Shell: zsh 5.9
       .|||||.                            '::::::::          Editor: nvim NVIM v0.9.1
      .|||||||:                             ::::::::         Resolution: 3440x1440 @ 144.00Hz
      |||||||:          .::::::::.           ::::::::        WM: bspwm
 ######||||||'   ##^ v##########v::. #####  #############v   Theme: gnome [GTK2]
  ######||||| ##^ v####::::::####v::#####  #####:::::#####   Icons: Adwaita [GTK2]
   ######||##^   #####::::::#####::#####  #####:::::######   Cursor: Adwaita [GTK2]
    ######^||    #####:::::####^::#####  #####:::::#####^    Terminal: alacritty
     ##^|||||    ^###########^:::#####  ##############^      Terminal Font: monospace
      |||||||:          '::::::::'          .::::::::        CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
      '|||||||:                            .::::::::'        GPU: NVIDIA GeForce RTX 4070
       '|||||||:.                           '::::::          Memory: 11.65 GiB / 31.29 GiB (37%)
        '||||||||:.                           ':::           Network: 1 Gbps
         ':|||||||||.                .          '            Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
           '|||||||||||:...    ...:||||.                     BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)
             ':||||||||||||||||||||||||||.
                ':|||||||||||||||||||||||''
                   '':||||||||||||||:''
                          ''''''


python3 -mhyfetch -p transgender --distro void  0.56s user 0.08s system 101% cpu 0.636 total

$ time python3 -mhyfetch -p transgender --distro arch
                                         mariell@mariellh-void
                   -`                    ---------------------
                  .o+`                   OS: Void Linux x86_64
                 `ooo/                   Host: B450M DS3H
                `+oooo:                  Kernel: 6.3.13_1
               `+oooooo:                 Uptime: 7 hours, 58 mins
               -+oooooo+:                Packages: 626 (xbps-query)
             `/:-:++oooo+:               Shell: zsh 5.9
            `/++++/+++++++:              Editor: nvim NVIM v0.9.1
           `/++++++++++++++:             Resolution: 3440x1440 @ 144.00Hz
          `/+++ooooooooooooo/`           WM: bspwm
         ./ooosssso++osssssso+`          Theme: gnome [GTK2]
        .oossssso-````/ossssss+`         Icons: Adwaita [GTK2]
       -osssssso.      :ssssssso.        Cursor: Adwaita [GTK2]
      :osssssss/        osssso+++.       Terminal: alacritty
     /ossssssss/        +ssssooo/-       Terminal Font: monospace
   `/ossssso+/:-        -:/+osssso+-     CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
  `+sso+:-`                 `.-/+oso:    GPU: NVIDIA GeForce RTX 4070
 `++:.                           `-/+/   Memory: 11.64 GiB / 31.29 GiB (37%)
 .`                                 `/   Network: 1 Gbps
                                         Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
                                         BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)




python3 -mhyfetch -p transgender --distro arch  0.36s user 0.08s system 102% cpu 0.421 total

$ time python3 -mhyfetch -p transgender --distro ubuntu
                                              mariell@mariellh-void
                             ....             ---------------------
              .',:clooo:  .:looooo:.          OS: Void Linux x86_64
           .;looooooooc  .oooooooooo'         Host: B450M DS3H
        .;looooool:,''.  :ooooooooooc         Kernel: 6.3.13_1
       ;looool;.         'oooooooooo,         Uptime: 7 hours, 58 mins
      ;clool'             .cooooooc.  ,,      Packages: 626 (xbps-query)
         ...                ......  .:oo,     Shell: zsh 5.9
  .;clol:,.                        .loooo'    Editor: nvim NVIM v0.9.1
 :ooooooooo,                        'ooool    Resolution: 3440x1440 @ 144.00Hz
'ooooooooooo.                        loooo.   WM: bspwm
'ooooooooool                         coooo.   Theme: gnome [GTK2]
 ,loooooooc.                        .loooo.   Icons: Adwaita [GTK2]
   .,;;;'.                          ;ooooc    Cursor: Adwaita [GTK2]
       ...                         ,ooool.    Terminal: alacritty
    .cooooc.              ..',,'.  .cooo.     Terminal Font: monospace
      ;ooooo:.           ;oooooooc.  :l.      CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
       .coooooc,..      coooooooooo.          GPU: NVIDIA GeForce RTX 4070
         .:ooooooolc:. .ooooooooooo'          Memory: 11.65 GiB / 31.29 GiB (37%)
           .':loooooo;  ,oooooooooc           Network: 1 Gbps
               ..';::c'  .;loooo:'            Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
                             .                BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)




python3 -mhyfetch -p transgender --distro ubuntu  0.40s user 0.07s system 102% cpu 0.461 total

$ time python3 -mhyfetch -p transgender --distro windows10
                                      mariell@mariellh-void
                                ..,   ---------------------
                    ....,,:;+ccllll   OS: Void Linux x86_64
      ...,,+:;  cllllllllllllllllll   Host: B450M DS3H
,cclllllllllll  lllllllllllllllllll   Kernel: 6.3.13_1
llllllllllllll  lllllllllllllllllll   Uptime: 8 hours
llllllllllllll  lllllllllllllllllll   Packages: 626 (xbps-query)
llllllllllllll  lllllllllllllllllll   Shell: zsh 5.9
llllllllllllll  lllllllllllllllllll   Editor: nvim NVIM v0.9.1
llllllllllllll  lllllllllllllllllll   Resolution: 3440x1440 @ 144.00Hz
                                      WM: bspwm
llllllllllllll  lllllllllllllllllll   Theme: gnome [GTK2]
llllllllllllll  lllllllllllllllllll   Icons: Adwaita [GTK2]
llllllllllllll  lllllllllllllllllll   Cursor: Adwaita [GTK2]
llllllllllllll  lllllllllllllllllll   Terminal: alacritty
llllllllllllll  lllllllllllllllllll   Terminal Font: monospace
`'ccllllllllll  lllllllllllllllllll   CPU: AMD Ryzen 7 5800X (16) @ 3.8GHz
       `' \*::  :ccllllllllllllllll   GPU: NVIDIA GeForce RTX 4070
                       ````''*::cll   Memory: 11.67 GiB / 31.29 GiB (37%)
                                 ``   Network: 1 Gbps
                                      Bluetooth: Cambridge Silicon Radio, Ltd Bluetooth Dongle (HCI mode)
                                      BIOS: American Megatrends International, LLC. 5.17 (03/29/2021)




python3 -mhyfetch -p transgender --distro windows10  0.34s user 0.08s system 102% cpu 0.403 total
```

And here are some screenshots from after showing it hasn't changed:

![image](https://github.com/hykilpikonna/hyfetch/assets/19861299/8f7f9030-43d8-4c2d-9ee6-b456ac7fdad8)
![image](https://github.com/hykilpikonna/hyfetch/assets/19861299/b8e1099e-0377-4d21-8038-d11c121fa4bd)
![image](https://github.com/hykilpikonna/hyfetch/assets/19861299/cb1f4ee6-5cd4-4101-970c-d4c49342988e)

Tested with:
- GNU bash, version 5.2.15(1)-release (x86_64-unknown-linux-gnu)
- sed (GNU sed) 4.9