### PR TITLE
Properly make use of the config file argument

### DIFF
--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -27,7 +27,7 @@ def check_config(path) -> Config:
     """
     if path.is_file():
         try:
-            return Config.from_dict(json.loads(CONFIG_PATH.read_text('utf-8')))
+            return Config.from_dict(json.loads(path.read_text('utf-8')))
         except KeyError:
             return create_config()
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Address the issue raised in #176, which is that -C was silently failing to load config files that were not in the default path. The problem was that `check_config` was checking that the path given in -C was a valid file, and then loading CONFIG_PATH instead, which was not being set to what was given in -C.

This behavior is shown in the attached screenshot.

### Relevant Links
#176 

### Screenshots
Before
![config](https://github.com/hykilpikonna/hyfetch/assets/31324979/82a806fa-efe1-4200-95e2-342f87ec6e22)

After
![config](https://github.com/hykilpikonna/hyfetch/assets/31324979/fed358b0-f6b0-4412-8afc-40bde94f34b8)
