### PR TITLE
Add ability to set backend args in config file

### DIFF
--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -401,6 +401,8 @@ def run():
         config.mode = args.mode
     if args.backend:
         config.backend = args.backend
+    if args.args:
+        config.args = args.args
 
     # Override global color mode
     GLOBAL_CFG.color_mode = config.mode
@@ -421,7 +423,7 @@ def run():
     try:
         asc = get_distro_ascii() if not args.ascii_file else Path(args.ascii_file).read_text("utf-8")
         asc = config.color_align.recolor_ascii(asc, preset)
-        neofetch_util.run(asc, config.backend, args.args or '')
+        neofetch_util.run(asc, config.backend, config.args or '')
     except Exception as e:
         print(f'Error: {e}')
         traceback.print_exc()

--- a/hyfetch/models.py
+++ b/hyfetch/models.py
@@ -16,6 +16,7 @@ class Config:
     lightness: float | None = None
     color_align: ColorAlignment = field(default_factory=lambda: ColorAlignment('horizontal'))
     backend: BackendLiteral = "neofetch"
+    args: str | None = None
     distro: str | None = None
     pride_month_shown: list[int] = field(default_factory=list)  # This is deprecated, see issue #136
     pride_month_disable: bool = False


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Adds the option to set permanent backend args in the config file.

### Relevant Links
#180

### Screenshots
In this example, I just disable printing the DE, WM, and GPU info.

![config](https://github.com/hykilpikonna/hyfetch/assets/31324979/04b7e176-be37-427d-9027-39cf7e3a65e0)