### PR TITLE
neofetch: use new AOSC OS logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -7230,28 +7230,25 @@ EOF
         ;;
 
         "AOSC OS"*)
-            set_colors 4 7 1
+            set_colors 4 0 1 3
             read -rd '' ascii_data <<'EOF'
-${c2}             .:+syhhhhys+:.
-         .ohNMMMMMMMMMMMMMMNho.
-      `+mMMMMMMMMMMmdmNMMMMMMMMm+`
-     +NMMMMMMMMMMMM/   `./smMMMMMN+
-   .mMMMMMMMMMMMMMMo        -yMMMMMm.
-  :NMMMMMMMMMMMMMMMs          .hMMMMN:
- .NMMMMhmMMMMMMMMMMm+/-         oMMMMN.
- dMMMMs  ./ymMMMMMMMMMMNy.       sMMMMd
--MMMMN`      oMMMMMMMMMMMN:      `NMMMM-
-/MMMMh       NMMMMMMMMMMMMm       hMMMM/
-/MMMMh       NMMMMMMMMMMMMm       hMMMM/
--MMMMN`      :MMMMMMMMMMMMy.     `NMMMM-
- dMMMMs       .yNMMMMMMMMMMMNy/. sMMMMd
- .NMMMMo         -/+sMMMMMMMMMMMmMMMMN.
-  :NMMMMh.          .MMMMMMMMMMMMMMMN:
-   .mMMMMMy-         NMMMMMMMMMMMMMm.
-     +NMMMMMms/.`    mMMMMMMMMMMMN+
-      `+mMMMMMMMMNmddMMMMMMMMMMm+`
-         .ohNMMMMMMMMMMMMMMNho.
-             .:+syhhhhys+:.
+${c2}                  __
+               ${c2}gpBBBBBBBBBP
+           ${c2}_gBBBBBBBBBRP
+         ${c2}4BBBBBBBBRP  ${c4},_____
+              ${c2}`"" ${c4}_g@@@@@@@@@@@@@%g>
+              ${c4}__@@@@@@@@@@@@@@@@P"  ${c1}___
+           ${c4}_g@@@@@@@@@@@@@@@N"` ${c1}_gN@@@@@N^
+       ${c4}_w@@@@@@@@@@@@@@@@P" ${c1}_g@@@@@@@P"
+    ${c4}_g@@@@@@@@@@@@@@@N"`  ${c1}VMNN@NNNM^`
+  ${c4}^MMM@@@@@@@@@@@MP" ${c3},ggppww__
+          ${c4}`""""" ${c3}_wNNNNNNNNNNNNNNNNNNN
+              ${c3}_gBNNNNNNNNNNNNNNNNNP"
+          ${c3}_wNNNNNNNNNNNNNNNNNNMP`
+       ${c3}_gBNNNNNNNNNNNNNNNNNP"
+   ${c3}_wNNNNNNNNNNNNNNNNNNNM^
+   ${c3}""Y^^MNNNNNNNNNNNNP`
+           ${c3}`"""""""
 EOF
         ;;
 


### PR DESCRIPTION
### Description

This pull requests updates the AOSC OS logo to our new design, as illustrated below.

![logo3](https://github.com/hykilpikonna/hyfetch/assets/5006263/6481afdf-8942-4677-90a3-a5863bb98dc6)

### Relevant Links

See our [logo repository](https://github.com/AOSC-Dev/logo).

### Screenshots

Before

![图片](https://github.com/hykilpikonna/hyfetch/assets/5006263/d56e32d7-2ade-422c-b1b8-142274bc7158)

After

![图片](https://github.com/hykilpikonna/hyfetch/assets/5006263/e01f41cf-e205-45db-b9e8-9caf2f120498)

### Additional context

N/A
