### PR TITLE
[F] Use /etc/debian_version to get .x on Debian

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1159,12 +1159,22 @@ get_distro() {
                 fi
 
             elif type -p lsb_release >/dev/null; then
-                case $distro_shorthand in
-                    on)   lsb_flags=-si ;;
-                    tiny) lsb_flags=-si ;;
-                    *)    lsb_flags=-sd ;;
-                esac
-                distro=$(lsb_release "$lsb_flags")
+                # Debian does not include .x versions in /etc/os-version, but does in debian_version
+                if [[ -f /etc/debian_version ]]; then
+                    . /etc/os-release
+                    case $distro_shorthand in
+                        on)   distro="${NAME}" ;;
+                        tiny) distro="$(lsb_release -si)" ;;
+                        *)    distro="${NAME} $(< /etc/debian_version) (${VERSION_CODENAME})" ;;
+                    esac
+                else
+                    case $distro_shorthand in
+                        on)   lsb_flags=-si ;;
+                        tiny) lsb_flags=-si ;;
+                        *)    lsb_flags=-sd ;;
+                    esac
+                    distro=$(lsb_release "$lsb_flags")
+                fi
 
             elif [[ -f /etc/os-release || \
                     -f /usr/lib/os-release || \


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
/etc/os-release on Debian only reports the major version, so use mix os-release and debian_version to build PRETTY_NAME.

### Relevant Links
#189 

### Screenshots
Before
![debianversion_old](https://github.com/hykilpikonna/hyfetch/assets/31324979/91394e7f-b810-4793-a8f9-a8366d71d622)

After
![debianversion](https://github.com/hykilpikonna/hyfetch/assets/31324979/36e02401-eea9-4a7b-ac4e-7d63f007b130)


### Additional context
I haven't had a chance to test if this break Ubuntu yet.
