### PR TITLE
README: Add repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Currently, these distributions have existing packages for HyFetch:
   emerge -a hyfetch
   ```
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/hyfetch.svg)](https://repology.org/project/hyfetch/versions)
 
 ### Method 3: Install the latest developmental version using git
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description

Easily see which repositories have a package for `hyfetch`, as well as what version.

### Relevant Links

https://repology.org/project/hyfetch/badges

### Screenshots

[![Packaging status](https://repology.org/badge/vertical-allrepos/hyfetch.svg)](https://repology.org/project/hyfetch/versions)

### Additional context

Recently Hyfetch was [packaged in Homebrew](https://github.com/search?q=org%3AHomebrew+hyfetch&type=pullrequests). I plan to help package it for Fedora as well.