### PR TITLE
Add logo and colours for Adélie Linux, and for Tru64 UNIX

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -6446,7 +6446,7 @@ ASCII:
     --ascii_colors x x x x x x  Colors to print the ascii art
     --ascii_distro distro       Which Distro's ascii art to print
 
-                                NOTE: AIX, AlmaLinux, Alpine, Alter, Amazon, AmogOS, Anarchy,
+                                NOTE: Adélie, AIX, AlmaLinux, Alpine, Alter, Amazon, AmogOS, Anarchy,
                                 Android, Antergos, antiX, AOSC OS, Afterglow, Aperio GNU/Linux,
                                 Aperture, Apricity, Arch, ArchBox, Archcraft, archcraft_ascii,
                                 archcraft_minimal, ARCHlabs, ArchMerge, ArchStrike, ArcoLinux,


### PR DESCRIPTION
### Description
This adds logos and colours to `neofetch` for the Adélie Linux distribution, and because I didn't split it to a different set of commits (silly me), lays the groundwork for supporting Tru64 / Digital UNIX / OSF/1 that I intend to further flesh out at a future point (read: when I can test any changes more complex than I've made thus far). 

### Relevant Links
[The old upstream neofetch had support requested for Adélie, but it never got merged in.](https://github.com/dylanaraps/neofetch/issues/1930)

[Adélie Linux homepage](https://www.adelielinux.org/) 
[Tru64 UNIX on en.wiki](https://en.wikipedia.org/wiki/Tru64_UNIX)
