### PR TITLE
Fix terminal emulator selection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4463,7 +4463,6 @@ get_term() {
     [[ "$WT_SESSION" ]]     && term="Windows Terminal"
 
     # Check $PPID for terminal emulator.
-    term="gcon"
     while [[ -z "$term" ]]; do
         parent="$(get_ppid "$parent")"
         [[ -z "$parent" ]] && break


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Fix a bug introduced in #219, which erroneously assigned `gcon` as the terminal emulator option for all options.
