### PR TITLE
Adds instruction to install on Debian.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Currently, these distributions have existing packages for HyFetch:
 * Homebrew: `brew install hyfetch` (Thanks to [@BKasin](https://github.com/BKasin) and [@osalbahr](https://github.com/osalbahr))
 * openSUSE Tumbleweed: `zypper in python311-hyfetch` (Thanks to [@BKasin](https://github.com/BKasin))
 * Gentoo: `emerge --ask app-misc/hyfetch` (Thanks to [@BKasin](https://github.com/BKasin))
+* Debian `apt install hyfetch` (for Debian flavor >= [Trixie](https://packages.debian.org/trixie/hyfetch))
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/hyfetch.svg)](https://repology.org/project/hyfetch/versions)
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
This PR adds installation instruction for Debian.

### Relevant Links
The link to the Debian package information is included.

### Screenshots
n/a

### Additional context
Since Debian Trixie the package `hyfetch` is in the official repository.

**edit:** Just now have seen that there was an issue created for it #205. All the praise has to go to @BKasin for preparing the Debian package.

