### PR TITLE
Fix Git package download

### DIFF
--- a/hyfetch/constants.py
+++ b/hyfetch/constants.py
@@ -51,4 +51,4 @@ class GlobalConfig:
 
 GLOBAL_CFG = GlobalConfig(color_mode='8bit', override_distro=None, debug=False, is_light=False, use_overlay=False)
 
-MINGIT_URL = 'https://github.com/git-for-windows/git/releases/download/v2.37.2.windows.2/MinGit-2.37.2.2-busybox-32-bit.zip'
+GIT_URL = 'https://github.com/git-for-windows/git/releases/download/v2.37.2.windows.2/Git-2.37.2.2-32-bit.tar.bz2'


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
On Windows, hyfetch offers to install a "minimal package for Git" if `bash.exe` is not found in Git's default installation path or `%PATH%`. However, this feature has two problems that prevent it from working.

- It attempts to download into `min_git` folder which does not exist after fresh install.
- It downloads the `MinGit` variant, which does not contain Git Bash at all!! That means even after successfully extracting the package, `bash.exe` still can't be found.

This pull request fixes these by auto-creating the folder and downloading the full Git package instead, with corresponding change in output message.

**TODO:** It would be better to install a standalone version of MinGW Bash, instead of downloading a full Git only for the Bash.

### Relevant Links

### Screenshots
Before the fix (caused by nonexistent `min_git`):
![before](https://github.com/hykilpikonna/hyfetch/assets/8153358/61ea6b5a-bee4-4fde-a427-2036ecfcc956)

After the fix (working properly):
![after](https://github.com/hykilpikonna/hyfetch/assets/8153358/f41a4b8b-d26e-437f-8963-9db8ccc79b9f)

### Additional context
More problems exist with the (un)installation of hyfetch on Windows, especially when installing from Git or local directory instead of pypi. I'll open an issue for that.
