### PR TITLE
Fix terminal font info for yakuake (again)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4654,8 +4654,8 @@ END
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"
 
-            # Loop while the process name is not "konsole"
-            while [[ "$(ps -p "$(get_ppid "$child")" -o comm=)" != "konsole" ]]; do
+            # Loop while the process name is not "konsole"/"yakuake"
+            while [[ "$(ps -p "$(get_ppid "$child")" -o comm=)" != "$term" ]]; do
                 # Get the parent process ID
                 child="$(get_ppid "$child")"
 


### PR DESCRIPTION
### Description

Make terminal font information show in both Konsole and Yakuake. Before this fix, terminal font only shows in Konsole but not in Yakuake.

### Relevant Links

This was once fixed in dylanaraps#1615 (also by me), when I found the code only matched the name against `"konsole"` but not `"yakuake"`. However the additional code that fixed hykilpikonna#116 made the same mistake by matching the name only against `"konsole"`, thus produced this bug again for Yakuake.

### Screenshots

Before:
![before](https://github.com/hykilpikonna/hyfetch/assets/2662820/c4d56bd9-e5b4-432e-918e-3aa558ceff7e)

After:
![after](https://github.com/hykilpikonna/hyfetch/assets/2662820/5febd9c6-c002-4e65-9d1a-8db51a855724)
