### PR TITLE
[F] Align Linux distro detection with upstream Neofetch's behavior

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1209,8 +1209,8 @@ get_distro() {
                     -f /etc/lsb-release ]]; then
 
                 # Source the os-release file
-                for file in /etc/lsb-release    /etc/os-release \
-                            /usr/lib/os-release /etc/openwrt_release; do
+                for file in /etc/lsb-release /usr/lib/os-release \
+                            /etc/os-release  /etc/openwrt_release; do
                     source "$file" && break
                 done
 


### PR DESCRIPTION
The previous behavior of sourcing /etc/os-release *before* /usr/lib/os-release causes janks especially when we need to spoof our machine as another distro by altering /etc/os-release, such as Ubuntu LTS for Microsoft Intune enrollment. Most of the apps that rely on os-release's presence always rely on the one in /etc/, skipping the one in /usr/lib/, so it's safe to assume this will make the distro detection more reliable.

The behavior prior to this change is given in the asciinema recording below:
Link: https://asciinema.org/a/647313


<!-- Thank you so much for contributing! ❤️ -->

### Description
This PR aligns os-release location handling with that of upstream `neofetch`, fixing incorrect distro detection in systems that are spoofed for various reasons (such as enrolling an Arch machine on Microsoft Intune).

### Relevant Links
See #243.

### Screenshots
#### Before
![Screenshot from 2024-03-17 11-56-57](https://github.com/hykilpikonna/hyfetch/assets/39265461/5c60bafb-6c29-4d44-9e0c-6cc543ba5548)
> (I was overriding the distro ASCII in my config to somewhat work around the issue.)

#### After
![Screenshot from 2024-03-17 11-57-34](https://github.com/hykilpikonna/hyfetch/assets/39265461/0ad0c191-48d0-4a04-8d5d-a51df13b2215)