### PR TITLE
neowofetch: Add `--package_minimal` option

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -235,6 +235,15 @@ package_managers="on"
 # off: '17 packages (flatpak)'
 package_separate="on"
 
+# Reduce output of packages list by not showing programming language package managers or Steam games
+#
+# Flag:    --package_minimal
+#
+# Example:
+# default:  'Packages: 1 (npm), 991 (emerge), 3 (steam), 23 (flatpak-system)'
+# minimal: 'Packages: 991 (emerge), 23 (flatpak-system)'
+package_minimal=""
+
 
 # Shell
 
@@ -2066,28 +2075,29 @@ get_packages() {
         }
     }
 
-    # OS-independent package managers.
-    has pipx  && tot pipx list --short
-    has cargo && _cargopkgs="$(cargo install --list | grep -v '^ ')" && tot echo "$_cargopkgs"
-    has am    && pac "$(am -f --less)"
+    # Programming language package managers.
+    if [[ -z "$package_minimal" ]]; then
+        has pipx  && tot pipx list --short
+        has cargo && _cargopkgs="$(cargo install --list | grep -v '^ ')" && tot echo "$_cargopkgs"
 
-    # Special case for npm: If has npm, we should list folders under node_modules instead of using npm list.
-    # This is because npm list is very slow (2s)
-    if has npm; then
-        # Try to apply heuristics to find the global directory.
-        if [[ -d /usr/lib/node_modules ]]; then
-            dir /usr/lib/node_modules/*/
-        elif [[ -d /usr/local/lib/node_modules ]]; then
-            dir /usr/local/lib/node_modules/*/
-        else
-            # If neither exist, use npm root -g to get the global directory.
-            # (still ~10x faster than npm list)
-            npm_global=$(npm root -g)
-            [[ -d $npm_global ]] && dir "$npm_global"/*/
+        # Special case for npm: If has npm, we should list folders under node_modules instead of using npm list.
+        # This is because npm list is very slow (2s)
+        if has npm; then
+            # Try to apply heuristics to find the global directory.
+            if [[ -d /usr/lib/node_modules ]]; then
+                dir /usr/lib/node_modules/*/
+            elif [[ -d /usr/local/lib/node_modules ]]; then
+                dir /usr/local/lib/node_modules/*/
+            else
+                # If neither exist, use npm root -g to get the global directory.
+                # (still ~10x faster than npm list)
+                npm_global=$(npm root -g)
+                [[ -d $npm_global ]] && dir "$npm_global"/*/
 
-            # This may not work in WSL2 (if npm is installed on Windows, not WSL).
-            # However, if npm is not installed on this WSL subsystem, it doesn't really count
-            # as a package manager for this subsystem, so let's ignore this case.
+                # This may not work in WSL2 (if npm is installed on Windows, not WSL).
+                # However, if npm is not installed on this WSL subsystem, it doesn't really count
+                # as a package manager for this subsystem, so let's ignore this case.
+            fi
         fi
     fi
 
@@ -2121,6 +2131,7 @@ get_packages() {
             has squirrel   && tot ls /var/packages
             has pkgx       && tot find "$HOME/.pkgx" -maxdepth 2 -mindepth 2 -type d
             has anise      && tot anise s --installed
+            has am         && pac "$(am -f --less)"
 
             # Using the dnf package cache is much faster than rpm.
             if has dnf && type -p sqlite3 >/dev/null && [[ -f /var/cache/dnf/packages.db ]]; then
@@ -2155,14 +2166,16 @@ get_packages() {
             shopt -u nullglob
             }
 
-            # Steam games
-            STEAM_P=".local/share/Steam/steamapps/common"
-            if [[ -d "$HOME/$STEAM_P" ]]; then
-                manager=steam && dir "$HOME/$STEAM_P/*/"
-            elif [[ -d "$HOME/.var/app/com.valvesoftware.Steam/$STEAM_P" ]]; then
-                manager=steam && dir "$HOME/.var/app/com.valvesoftware.Steam/$STEAM_P/*/"
-            elif [[ -d "$HOME/.steam/steam/steamapps/common" ]]; then
-                manager=steam && dir "$HOME/.steam/steam/steamapps/common/*/"
+            if [[ -z "$package_minimal" ]]; then
+                # Steam games
+                STEAM_P=".local/share/Steam/steamapps/common"
+                if [[ -d "$HOME/$STEAM_P" ]]; then
+                    manager=steam && dir "$HOME/$STEAM_P/*/"
+                elif [[ -d "$HOME/.var/app/com.valvesoftware.Steam/$STEAM_P" ]]; then
+                    manager=steam && dir "$HOME/.var/app/com.valvesoftware.Steam/$STEAM_P/*/"
+                elif [[ -d "$HOME/.steam/steam/steamapps/common" ]]; then
+                    manager=steam && dir "$HOME/.steam/steam/steamapps/common/*/"
+                fi
             fi
 
             # Other (Needs complex command)
@@ -6368,6 +6381,7 @@ INFO:
     --title_fqdn on/off         Hide/Show Fully Qualified Domain Name in title.
     --package_managers on/off   Hide/Show Package Manager names. (on, tiny, off)
     --package_separate on/off   Whether to separate system/user modes for supported package managers
+    --package_minimal           Reduce output of packages list by not showing programming language package managers or Steam games
     --os_arch on/off            Hide/Show OS architecture.
     --speed_type type           Change the type of cpu speed to display.
                                 Possible values: current, min, max, bios,
@@ -6637,6 +6651,7 @@ get_args() {
             "--title_fqdn") title_fqdn="$2" ;;
             "--package_managers") package_managers="$2" ;;
             "--package_separate") package_separate="$2" ;;
+            "--package_minimal") package_minimal="1" ;;
             "--os_arch") os_arch="$2" ;;
             "--cpu_cores") cpu_cores="$2" ;;
             "--cpu_speed") cpu_speed="$2" ;;


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Reduces 'packages' output by omitting language package managers and Steam games, improving execution speed and reducing visual clutter

### Relevant Links
Somewhat addresses #246 

### Screenshots
![image](https://github.com/hykilpikonna/hyfetch/assets/48618519/11cb395f-233f-41b1-b48b-7433db4634ba)

### Additional context
I have also moved the `am` package manager in with the other Linux package managers, as it is a Linux-only package manager