### PR TITLE
Use kinfo when plasma6 is detected

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2546,9 +2546,20 @@ get_de() {
     esac
 
     ((${KDE_SESSION_VERSION:-0} >= 4)) && de=${de/KDE/Plasma}
+    ((${KDE_SESSION_VERSION:-0} >= 6)) && de=${de/Plasma/Plasma6}
 
     if [[ $de_version == on && $de ]]; then
         case $de in
+            Plasma6*)
+                       de_ver=$(plasmashell --version)
+                       kf_ver=$(kinfo)
+                       qt_ver=${kf_ver/Kernel*}
+                       qt_ver=${qt_ver/*:}
+                       qt_ver=$(trim "$qt_ver")
+                       kf_ver=${kf_ver/Qt*}
+                       kf_ver=${kf_ver/*:}
+                       kf_ver=$(trim "$kf_ver")
+            ;;
             Plasma*)
                        de_ver=$(plasmashell --version)
                        kf_ver=$(kf5-config --version)
@@ -2582,7 +2593,7 @@ get_de() {
 
         de+=" $de_ver"
 
-        [[ $de == "Plasma"* ]] && de+=" [KF5 $kf_ver] [Qt $qt_ver]"
+        [[ $de == "Plasma"* ]] && de="Plasma $de_ver [KF $kf_ver] [Qt $qt_ver]"
     fi
 
     # TODO:


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Plasma 6 removed the `kf5-config` tool that was used to detect version info on KDE, replacing it with `kinfo`. So if version 4 or 5 is detected, continue using `kf5-config` like the previous logic did, if version 6 is detected swap to `kinfo` instead.

### Relevant Links
#239 

### Screenshots
![image](https://github.com/hykilpikonna/hyfetch/assets/31324979/85c740d4-2fdf-441a-8417-0914d1eb353f)
