### PR TITLE
Add `Apple_Terminal` to list of special cases in get_term()

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4533,7 +4533,7 @@ get_term() {
     # don't support the block below.
     case $TERM_PROGRAM in
         "iTerm.app")    term="iTerm2" ;;
-        "Terminal.app") term="Apple Terminal" ;;
+        "Terminal.app"|"Apple_Terminal") term="Apple Terminal" ;;
         "Hyper")        term="HyperTerm" ;;
         *)              term="${TERM_PROGRAM/\.app}" ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -4532,10 +4532,10 @@ get_term() {
     # Workaround for macOS systems that
     # don't support the block below.
     case $TERM_PROGRAM in
-        "iTerm.app")    term="iTerm2" ;;
-        "Terminal.app"|"Apple_Terminal") term="Apple Terminal" ;;
-        "Hyper")        term="HyperTerm" ;;
-        *)              term="${TERM_PROGRAM/\.app}" ;;
+        "iTerm.app")                     term="iTerm2"                ;;
+        "Terminal.app"|"Apple_Terminal") term="Apple Terminal"        ;;
+        "Hyper")                         term="HyperTerm"             ;;
+        *)                               term="${TERM_PROGRAM/\.app}" ;;
     esac
 
     # Most likely TosWin2 on FreeMiNT - quick check


### PR DESCRIPTION
At some point Apple changed the value set by their terminal I guess