### PR TITLE
Add exception for KDE neon to *buntu version check

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1197,7 +1197,7 @@ get_distro() {
             elif type -p lsb_release >/dev/null; then
                 # Debian does not include .x versions in /etc/os-version, but does in debian_version
                 # So if that file exists, and we are not *buntu, build name from there
-                if [[ -f /etc/debian_version ]] && [[ $(lsb_release -si) != *"buntu"* ]]; then
+                if [[ -f /etc/debian_version ]] && [[ $(lsb_release -si) != *"buntu"* ]] && [[ $(lsb_release -si) != *"neon"* ]]; then
                     . /etc/os-release
                     case $distro_shorthand in
                         on)   distro="${NAME}" ;;


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
KDE neon is based on Ubuntu and needs the same exception that is made for distros like Kubuntu for the OS name/version check.

### Relevant Links
#273 

### Screenshots
![image](https://github.com/hykilpikonna/hyfetch/assets/31324979/3d2b7b3b-e4c0-430e-bb15-ce2fa278e3bd)

