### PR TITLE
hyfetch is in Fedora official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Currently, these distributions have existing packages for HyFetch:
 
 * Universal [Lure.sh](https://lure.sh/): `lure in hyfetch` (Thanks to [@Elara6331](https://github.com/Elara6331))
 * Arch Linux: `sudo pacman -S hyfetch` (Thanks to [@Aleksana](https://github.com/Aleksanaa) and [@Antiz96](https://github.com/Antiz96))
+* Fedora Linux: `sudo dnf install hyfetch` (packaged by [@topazus](http://github.com/topazus))
 * Nix: `nix-env -i hyfetch` (Thanks to [@YisuiDenghua](https://github.com/YisuiDenghua))
 * Nix Profile: `nix profile install nixpkgs#hyfetch`
 * Guix: `guix install hyfetch` (Thanks to [@WammKD](https://github.com/WammKD))


### PR DESCRIPTION
### Description
Hyfetch is first available in Fedora rawhide repo, and then it will come into fedora 39 and 40 in a few days later.

resolve https://github.com/hykilpikonna/hyfetch/issues/208

### Relevant Links
https://bodhi.fedoraproject.org/updates/?packages=hyfetch