### PR TITLE
add Chimera Linux

### DIFF
--- a/docs/neofetch.1
+++ b/docs/neofetch.1
@@ -321,7 +321,7 @@ ArcoLinux, ArseLinux, Artix, Arya, Asahi, AsteroidOS, astOS, Astra
 Linux, Athena, azos, Bedrock, BigLinux, Bitrig, BlackArch,
 blackPanther, BLAG, BlankOn, BlueLight, Bodhi, bonsai, BSD,
 BunsenLabs, CachyOS, Calculate, CalinixOS, Carbs, CBL\-Mariner,
-CelOS, Center, CentOS, Chakra, ChaletOS, Chapeau, ChonkySealOS,
+CelOS, Center, CentOS, Chakra, ChaletOS, Chapeau, Chimera, ChonkySealOS,
 Chrom, Cleanjaro, Clear Linux OS, ClearOS, Clover, Cobalt, Condres,
 Container Linux by CoreOS, CRUX, Crystal Linux, Cucumber,
 CutefishOS, CuteOS, CyberOS, dahlia, DarkOs, Darwin, Debian, Deepin,

--- a/neofetch
+++ b/neofetch
@@ -870,7 +870,7 @@ image_source="auto"
 # archcraft_ascii, archcraft_minimal, ARCHlabs, ArchMerge, ArchStrike, ArcoLinux, ArseLinux, Artix,
 # Arya, Asahi, AsteroidOS, astOS, Astra Linux, Athena, azos, Bedrock, BigLinux, Bitrig, BlackArch,
 # blackPanther, BLAG, BlankOn, BlueLight, Bodhi, bonsai, BSD, BunsenLabs, CachyOS, Calculate,
-# CalinixOS, Carbs, CBL-Mariner, CelOS, Center, CentOS, Chakra, ChaletOS, Chapeau, ChonkySealOS,
+# CalinixOS, Carbs, CBL-Mariner, CelOS, Center, CentOS, Chakra, ChaletOS, Chapeau, Chimera, ChonkySealOS,
 # Chrom, Cleanjaro, Clear Linux OS, ClearOS, Clover, Cobalt, Condres, Container Linux by CoreOS,
 # CRUX, Crystal Linux, Cucumber, CutefishOS, CuteOS, CyberOS, dahlia, DarkOs, Darwin, Debian,
 # Deepin, DesaOS, Devuan, DietPi, digital UNIX, DracOS, DragonFly, Drauger, Droidian, Elementary,
@@ -6549,7 +6549,7 @@ ASCII:
                                 Linux, Athena, azos, Bedrock, BigLinux, Bitrig, BlackArch,
                                 blackPanther, BLAG, BlankOn, BlueLight, Bodhi, bonsai, BSD,
                                 BunsenLabs, CachyOS, Calculate, CalinixOS, Carbs, CBL-Mariner,
-                                CelOS, Center, CentOS, Chakra, ChaletOS, Chapeau, ChonkySealOS,
+                                CelOS, Center, CentOS, Chakra, ChaletOS, Chapeau, Chimera, ChonkySealOS,
                                 Chrom, Cleanjaro, Clear Linux OS, ClearOS, Clover, Cobalt, Condres,
                                 Container Linux by CoreOS, CRUX, Crystal Linux, Cucumber,
                                 CutefishOS, CuteOS, CyberOS, dahlia, DarkOs, Darwin, Debian, Deepin,
@@ -8741,6 +8741,30 @@ ${c1}               .-/-.
     `//////////${c2}++${c1}//////////
        `////////////////.
            -////////-
+EOF
+        ;;
+
+        "Chimera"*)
+            set_colors 1 5 4 1
+            read -rd '' ascii_data <<'EOF'
+${c3}ddddddddddddddc  ${c1},cc:
+${c3}ddddddddddddddc  ${c1},cc:
+${c3}ddddddddddddddd  ${c1},cc:
+${c3}ddddddddddddl:'  ${c1},cc:
+${c3}dddddddddl'    ${c1}..;cc:
+${c3}dddddddo.   ${c1},:cccccc:
+${c3}ddddddl   ${c1},ccc:'''''
+${c3}dddddo.  ${c1};ccc.          ............
+        .ccc.           cccccccccccc
+${c2}......  ${c1}.ccc.          .ccc'''''''''
+${c2}OOOOOk.  ${c1};ccc.        .ccc;   ......
+${c2}OOOOOOd   ${c1}'ccc:,....,:ccc'   ${c4}coooooo
+${c2}OOOOOOOx.   ${c1}':cccccccc:'   ${c4}.looooooo
+${c2}OOOOOOOOOd,     ${c1}`'''`     ${c4}.coooooooo
+${c2}OOOOOOOOOOOOdc,.    ${c4}..,coooooooooooo
+${c2}OOOOOOOOOOOOOOOO'  ${c4}.oooooooooooooooo
+${c2}OOOOOOOOOOOOOOOO'  ${c4}.oooooooooooooooo
+${c2}OOOOOOOOOOOOOOOO'  ${c4}.oooooooooooooooo
 EOF
         ;;
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Adds the Chimera Linux logo and colors.

> Chimera is a general-purpose OS born from unhappiness with the state of Linux distributions.
> It's built around the core idea that a simple system does not have to require endless setup and customization to be practical.

### Relevant Links
[Website](https://chimera-linux.org/)
[Download](https://repo.chimera-linux.org/live/latest/)
[GitHub Organization](https://github.com/chimera-linux)

### Screenshots
![Chimera Linux neowofetch](https://github.com/hykilpikonna/hyfetch/assets/169118047/4338f341-30bd-4f27-87bc-2dc2e444d0bb)