### PR TITLE
Update neofetch reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ neofetch with pride flags <3
 
 ### Running Updated Original Neofetch
 
-This repo also serves as an updated version of the original `neofetch` since the upstream [dylanaraps/neofetch](https://github.com/dylanaraps/neofetch) doesn't seem to be maintained anymore (as of Oct 27, 2023, the original repo hasn't merged a pull request for almost 2 years). If you only want to use the updated neofetch without pride flags, you can use the `neofetch` script from this repo. To prevent command name conflict, I call it `neowofetch` :)
+This repo also serves as an updated version of the original `neofetch` since the upstream [dylanaraps/neofetch](https://github.com/dylanaraps/neofetch) isn't maintained anymore and has been archived. If you only want to use the updated neofetch without pride flags, you can use the `neofetch` script from this repo. To prevent command name conflict, I call it `neowofetch` :)
 
 * Method 1: `pip install -U hyfetch` then run `neowofetch`
 * Method 2: `npx neowofetch`


### PR DESCRIPTION
# Description
Update information in regards to the orignal neofetch as it has been archived on Apr 26, 2024

# Relevant Links
https://github.com/dylanaraps/neofetch

# Screenshots

### Current
![Before](https://github.com/hykilpikonna/hyfetch/assets/130537361/1c18b12c-9a71-419f-a65b-2ac4e444022f)
### With Proposed Changes
![After](https://github.com/hykilpikonna/hyfetch/assets/130537361/fe16cf73-983a-4449-8a23-ed2fec4df6e7)