### PR TITLE
Support unicode ascii art on Windows

### DIFF
--- a/hyfetch/neofetch_util.py
+++ b/hyfetch/neofetch_util.py
@@ -344,7 +344,7 @@ def run_neofetch(asc: str, args: str = ''):
     with TemporaryDirectory() as tmp_dir:
         tmp_dir = Path(tmp_dir)
         path = tmp_dir / 'ascii.txt'
-        path.write_text(asc)
+        path.write_text(asc, 'utf-8')
 
         # Call neofetch with the temp file
         if args:
@@ -378,7 +378,7 @@ def run_fastfetch(asc: str, args: str = '', legacy: bool = False):
     with TemporaryDirectory() as tmp_dir:
         tmp_dir = Path(tmp_dir)
         path = tmp_dir / 'ascii.txt'
-        path.write_text(asc)
+        path.write_text(asc, 'utf-8')
 
         # Call fastfetch with the temp file
         proc = subprocess.run([ff_path, '--raw' if legacy else '--file-raw', path.absolute(), *shlex.split(args)])


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Support unicode ascii art on Windows. Windows Terminal can output UTF-8 characters. Configuration _may_ be needed on Windows 10.

### Relevant Links
Fixes #293

### Screenshots
Before: See issue.
After:
![image](https://github.com/hykilpikonna/hyfetch/assets/7243615/d3c8f491-7464-4d41-b843-5146ebfba2ae)

### Additional context
None.
