### PR TITLE
Make typing_extensions only required for 3.7

### DIFF
--- a/hyfetch/types.py
+++ b/hyfetch/types.py
@@ -1,4 +1,7 @@
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 AnsiMode = Literal['default', 'ansi', '8bit', 'rgb']
 LightDark = Literal['light', 'dark']

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     install_requires=[
         # Universal dependencies
-        'setuptools', 'typing_extensions',
+        'setuptools', 'typing_extensions; python_version < "3.8"',
         
         # Windows dependencies
         'psutil ; platform_system=="Windows"',


### PR DESCRIPTION
Literal was introduced in Python 3.8.


### Description

Allow Arch to drop python-typing_extensions as a dependency.

### Relevant Links

https://docs.python.org/3/library/typing.html#typing.Literal


