### PR TITLE
Fix ColorAlignment.custom_colors.keys() / slots type mismatch

### DIFF
--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -247,7 +247,7 @@ def create_config() -> Config:
 
         # Random color schemes
         pis = list(range(len(_prs.unique_colors().colors)))
-        slots = list(set(re.findall('(?<=\\${c)[0-9](?=})', asc)))
+        slots = list(set(map(int, re.findall('(?<=\\${c)[0-9](?=})', asc))))
         while len(pis) < len(slots):
             pis += pis
         perm = {p[:len(slots)] for p in permutations(pis)}

--- a/hyfetch/neofetch_util.py
+++ b/hyfetch/neofetch_util.py
@@ -129,7 +129,10 @@ class ColorAlignment:
 
     @classmethod
     def from_dict(cls, d: dict):
-        return from_dict(cls, d)
+        ca = from_dict(cls, d)
+        # Fixup: Keys must json serialize as str, so we convert them back to int.
+        ca.custom_colors = {int(k): v for k, v in ca.custom_colors.items()}
+        return ca
 
     def recolor_ascii(self, asc: str, preset: ColorProfile) -> str:
         """


### PR DESCRIPTION
This is something I am running into while working on an bigger PR (and need to resolve it) and I think it would be good to separately get a quick fix in.

In the `ColorAlignment` dataclass, the type annotation of [`custom_color`](https://github.com/hykilpikonna/hyfetch/blob/7534371b05ee877cdf3c4c3733b13d7c41d09c3e/hyfetch/neofetch_util.py#L125) keys (`int`) does not match the type of the of [slots](https://github.com/hykilpikonna/hyfetch/blob/7534371b05ee877cdf3c4c3733b13d7c41d09c3e/hyfetch/main.py#L247) (set of `str` (which are numeric characters)), which is used to construct the ColorAlignment instance. (The value of that field ends up not the correct type).

Additionally, since this value is saved in the `hyfetch.json`, serialization for json [only supports strings as keys](https://stackoverflow.com/questions/1450957/pythons-json-module-converts-int-dictionary-keys-to-strings) means that the keys go into the json as `str`s. And it's involved to avoid saving the keys as `str`. There are outstanding user configs already with serialized string keys. De-serializing those configs also result in `str` keys in the `custom_color` field.

I think the resolution is one of the following options:

1. Change the type annotation to `custom_colors: dict[str, int] = ()`
2. Fix the construction of `slots` to be a `set[int]`, and one of:
    a. Enhance the deserialization to generally recognise int str keys.
    b. Add a fixup step to `ColorAlignment.from_dict`

I chose solution 2b here as it is simple and it respects the apparent authorial intent that the `custom_colors` should be an `dict[int, int]`, which in general makes sense to me. This solution would not in any way preclude smoothly moving to `str` keys in the future if more `slot`s support is desired with for example letter based slots `${cA} ${cB}`.