### PR TITLE
Allow lightness values without a % to parse

### DIFF
--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -210,12 +210,15 @@ def create_config() -> Config:
                 return def_lightness
 
             try:
-                lightness = int(lightness[:-1]) / 100 if lightness.endswith('%') else float(lightness)
+                if lightness.endswith('%') or int(lightness) > 1:
+                    lightness = int(lightness[:-1]) / 100 if lightness.endswith('%') else int(lightness) / 100
+                else:
+                    lightness = float(lightness)
                 assert 0 <= lightness <= 1
                 return lightness
 
             except Exception:
-                printc('&cUnable to parse lightness value, please input it as a decimal or percentage (e.g. 0.5 or 50%)')
+                printc('&cUnable to parse lightness value, please enter a lightness value such as 45%, .45, or 45')
 
     lightness = select_lightness()
     _prs = _prs.set_light_dl(lightness, light_dark)


### PR DESCRIPTION
### Description
As a hyfetch user, when configuring hyfetch on a new system, I often get to the lightness value and enter '65' without a %, leading to me having to retry. Because of this,I thought that instead changing the parsing to allow values like '65', '.65', or '65%' to parse correctly, as well as updating the parse error to reflect the changes

### Screenshots
![image](https://github.com/hykilpikonna/hyfetch/assets/87090296/a2d7765e-60cc-4c1d-a98e-519c1ed84c14)

### Additional context
Alternatively, updating the lightness message: `Which brightness level looks the best? (Default: 65% for dark mode)` to mention the input options could also be good.
