### PR TITLE
xenogender flag preset added

### DIFF
--- a/hyfetch/presets.py
+++ b/hyfetch/presets.py
@@ -189,6 +189,17 @@ PRESETS: dict[str, ColorProfile] = {
         '#282828'
     ]),
 
+    # xenogender sourced from https://commons.wikimedia.org/wiki/File:Xenogender_pride_flag.svg
+    'xenogender': ColorProfile([
+        '#FF6692',
+        '#FF9A98',
+        '#FFB883',
+        '#FBFFA8',
+	'#85BCFF',
+	'#9D85FF',
+	'#A510FF'
+    ]),
+
     'agender': ColorProfile([
         '#000000',
         '#BABABA',


### PR DESCRIPTION
### Description
Adds the color preset for the [xenogender](https://lgbtqia.wiki/wiki/Xenogender) flag.
Flag colors sourced from: [here](https://commons.wikimedia.org/wiki/File:Xenogender_pride_flag.svg)

### Relevant Links
Requested on and resolves #301 