### PR TITLE
remove unneeded setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     install_requires=[
         # Universal dependencies
-        'setuptools', 'typing_extensions; python_version < "3.8"',
+        'typing_extensions; python_version < "3.8"',
         
         # Windows dependencies
         'psutil ; platform_system=="Windows"',


### PR DESCRIPTION
this was added back in 2b5ef302a5e8fd617de4974353e4afc29f4400d8 when pkg_resources was used, but that is no longer used since 5c34876c538cede13ffe8bf21275151b7259a511