### PR TITLE
neofetch: support MacPorts on Linux & BSD

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2153,6 +2153,7 @@ get_packages() {
             has squirrel   && tot ls /var/packages
             has anise      && tot anise s --installed
             has am         && pac "$(am -f --less)"
+            has port       && pkgs_h=1 tot port installed && ((packages-=1))
 
             # Using the dnf package cache is much faster than rpm.
             if has dnf && type -p sqlite3 >/dev/null && [[ -f /var/cache/dnf/packages.db ]]; then


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Support MacPorts packages info on non-Apple systems.

### Additional context
This is a trivial copy-paste of https://github.com/hykilpikonna/hyfetch/blob/95a6cc7f4b925772f59bf81a03f6038445b197e5/neofetch#L2295
