### PR TITLE
neofetch: support host info for PowerPC Macintosh models

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1698,6 +1698,23 @@ get_model() {
                     iMac11,2):              "iMac (21.5-inch, Mid 2010)" ;;
                     iMac10,1):              "iMac (27/21.5-inch, Late 2009)" ;;
                     iMac9,1):               "iMac (24/20-inch, Early 2009)" ;;
+                    PowerMac12,1):          "iMac G5 (20/17-inch, iSight)" ;;
+                    PowerMac11,2):          "Power Macintosh G5" ;;
+                    PowerMac8,2):           "iMac G5 (20/17-inch, ALS)" ;;
+                    PowerMac8,1):           "iMac G5 (20/17-inch)" ;;
+                    PowerMac7,[2-3]):       "Power Macintosh G5 (PCI/PCI-X)" ;;
+                    PowerMac6,4):           "eMac G4" ;;
+                    PowerMac6,3):           "iMac G4 (20/17/15-inch, USB 2.0)" ;;
+                    PowerMac6,1):           "iMac G4 (17-inch, Flat Panel)" ;;
+                    PowerMac5,1):           "Power Macintosh G4 Cube" ;;
+                    PowerMac4,5):           "iMac G4 (17-inch, Flat Panel)" ;;
+                    PowerMac4,4):           "eMac G4" ;;
+                    PowerMac4,1):           "iMac G3" ;;
+                    PowerMac3,6):           "Power Macintosh G4 (MDD/FW800)" ;;
+                    PowerMac3,5):           "Power Macintosh G4 (Quicksilver)" ;;
+                    PowerMac3,4):           "Power Macintosh G4 (Digital Audio)" ;;
+                    PowerMac3,3):           "Power Macintosh G4 (Gigabit)" ;;
+                    PowerMac3,1):           "Power Macintosh G4 (AGP)" ;;
                     *):                     "$model" ;;
                 esac
 

--- a/neofetch
+++ b/neofetch
@@ -1715,6 +1715,17 @@ get_model() {
                     PowerMac3,4):           "Power Macintosh G4 (Digital Audio)" ;;
                     PowerMac3,3):           "Power Macintosh G4 (Gigabit)" ;;
                     PowerMac3,1):           "Power Macintosh G4 (AGP)" ;;
+                    PowerBook6,8 | PowerBook6,4 | PowerBook6,1):    "PowerBook G4 (17/15/12-inch, Al)" ;;
+                    PowerBook6,7 | PowerBook6,5 | PowerBook6,3):    "iBook G4 (14/12-inch)" ;;
+                    PowerBook6,2):          "PowerBook G4 (12-inch, DVI - Al)" ;;
+                    PowerBook5,[8-9]):      "PowerBook G4 (17/15-inch, DLSD/HR - Al)" ;;
+                    PowerBook5,[3-7] | PowerBook5,1):               "PowerBook G4 (17/15/12-inch, Al)" ;;
+                    PowerBook5,2):          "PowerBook G4 (15-inch, FW800 - Al)" ;;
+                    PowerBook4,[1-3]):      "iBook G3" ;;
+                    PowerBook3,5):          "PowerBook G4 (Ti)" ;;
+                    PowerBook3,4):          "PowerBook G4 (DVI - Ti)" ;;
+                    PowerBook3,3):          "PowerBook G4 (Gigabit - Ti)" ;;
+                    PowerBook3,2):          "PowerBook G4 (Original - Ti)" ;;
                     *):                     "$model" ;;
                 esac
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Display humanly-readable model names instead of model codes.
