### PR TITLE
fix(neofetch): list all Intel GPUs as detected

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3429,15 +3429,6 @@ get_gpu() {
 
             IFS=$'\n' read -d "" -ra gpus <<< "$gpu_cmd"
 
-            # Remove duplicate Intel Graphics outputs.
-            # This fixes cases where the outputs are both
-            # Intel but not entirely identical.
-            #
-            # Checking the first two array elements should
-            # be safe since there won't be 2 intel outputs if
-            # there's a dedicated GPU in play.
-            [[ "${gpus[0]}" == *Intel* && "${gpus[1]}" == *Intel* ]] && unset -v "gpus[0]"
-
             for gpu in "${gpus[@]}"; do
                 # GPU shorthand tests.
                 [[ "$gpu_type" == "dedicated" && "$gpu" == *Intel* ]] || \


### PR DESCRIPTION
Now that Intel is selling its own dedicated GPUs, it is increasingly common to see laptops and desktop devices with multiple Intel GPUs. This patch is intended to fix GPU detection on a laptop with both an integrated UHD Graphics GPU and an Arc 380 (DG2).

Note that this may potentially cause regressions, but the original upstream did not record the original issue, so I'm inclined to write it off as an outdated fix:

```
  commit ee815f9c6651423ae93f8ead237ebc99e2373c06
  Author: Dylan Araps <dylan.araps@gmail.com>
  Date:   Mon Apr 9 09:51:23 2018 +1000

      gpu: Fixed duplicate intel bug.
```

<!-- Thank you so much for contributing! ❤️ -->

### Description
Describe the goals that the pull request accomplishes.

### Relevant Links
If there are related issues, please link them here.

Please also include links relevant to the changes.

e.g. For new distros, include a link to the distro's official website, download link, or development repository.

### Screenshots
If applicable, please include screenshots before and after your changes.

### Additional context
Add any other context about the problem or changes here.
