### PR TITLE
fix: run `neowofetch` directly on unix

### DIFF
--- a/crates/hyfetch/src/neofetch_util.rs
+++ b/crates/hyfetch/src/neofetch_util.rs
@@ -506,8 +506,7 @@ where
 
     #[cfg(not(windows))]
     {
-        let mut command = Command::new("bash");
-        command.arg(neofetch_path);
+        let mut command = Command::new(neofetch_path);
         command.args(args);
         Ok(command)
     }


### PR DESCRIPTION
### Description

`neowofetch` should contain a shebang and be directly executable, so we shouldn't be spawning a subshell for it

### Relevant Links

n/a

### Screenshots

n/a

### Additional context

This avoids `bash` being a hard dependency in the user's `$PATH` when using the neofetch backend. It also helps in packaging hyfetch for Nix, Guix, etc. where binaries have their `$PATH`s explicitly wrapped with external binaries that are called
