### PR TITLE
neofetch: Speed-up rpm total package count

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2199,7 +2199,7 @@ get_packages() {
             if has dnf && type -p sqlite3 >/dev/null && [[ -f /var/cache/dnf/packages.db ]]; then
                 pac "$(sqlite3 /var/cache/dnf/packages.db "SELECT count(pkg) FROM installed")"
             else
-                has rpm && tot rpm -qa
+                has rpm && tot rpm -qa --nodigest --nosignature
             fi
 
             # 'mine' conflicts with minesweeper games.
@@ -2360,7 +2360,7 @@ get_packages() {
 
         AIX|FreeMiNT)
             has lslpp && ((packages+=$(lslpp -J -l -q | grep -cv '^#')))
-            has rpm   && tot rpm -qa
+            has rpm   && tot rpm -qa --nodigest --nosignature
         ;;
 
         Windows)


### PR DESCRIPTION
On distros with RPM, neofetch slows down noticeably when counting system packages.

Skipping package digest and signature verification via command-line flags yields a significant speed-up.

Examples from my machine:
```
$ time rpm -qa | wc -l
5921

real    0m1,549s
user    0m1,459s
sys     0m0,106s

$ time rpm -qa --nodigest --nosignature | wc -l
5921

real    0m0,238s
user    0m0,148s
sys     0m0,102s
```

It could possibly also rival the speed of DNF's sqlite database lookup, though I haven't tried it.
