### PR TITLE
fix cpu fetching code for leopard and tiger

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3175,11 +3175,10 @@ END
         ;;
 
         "Mac OS X"|"macOS")
-            if [[ $osx_version == 10.[4-5]* ]]; then
+            cpu="$(sysctl -n machdep.cpu.brand_string 2>/dev/null)"
+            if [ -z "$cpu" ]; then
                 cpu="$(system_profiler SPHardwareDataType | grep Processor\ Name)"
                 cpu="${cpu/Processor\ Name\:/}"
-            else
-                cpu="$(sysctl -n machdep.cpu.brand_string)"
             fi
 
             # Get CPU cores.

--- a/neofetch
+++ b/neofetch
@@ -3176,16 +3176,8 @@ END
 
         "Mac OS X"|"macOS")
             if [[ $osx_version == 10.[4-5]* ]]; then
-                cpu="$(system_profiler SPHardwareDataType | grep CPU\ Type)"
-                cpu="${cpu/CPU\ Type\:/}"
-
-                speed="$(system_profiler SPHardwareDataType | grep CPU\ Speed)"
-                speed="${speed/CPU\ Speed\:/}"
-                speed="${speed/ MHz/}"
-                speed="${speed/ GHz/}"
-
-                cores="$(system_profiler SPHardwareDataType | grep Number\ Of\ CPUs)"
-                cores="${cores/Number\ Of\ CPUs\:/}"
+                cpu="$(system_profiler SPHardwareDataType | grep Processor\ Name)"
+                cpu="${cpu/Processor\ Name\:/}"
             else
                 cpu="$(sysctl -n machdep.cpu.brand_string)"
             fi
@@ -3374,7 +3366,6 @@ END
     cpu="${cpu//[1-9][0-9]-Core}"
     cpu="${cpu//[0-9]-Core}"
     cpu="${cpu//, * Compute Cores}"
-    cpu="${cpu//Core / }"
     cpu="${cpu//(\"AuthenticAMD\"*)}"
     cpu="${cpu//with Radeon*Graphics}"
     cpu="${cpu//, altivec supported}"


### PR DESCRIPTION
### Description
Fixed CPU string fetching code, I'm not sure why it was setup to find the string "CPU Type", as neither Tiger or Leopard use that

Removed CPU Speed fetching code.  It was also broken, looking for "CPU Speed" instead of "Processor Speed", and could be fixed, but fixing it would sometimes make it get a number with a decimal like 3.3 GHz, which broke some code later on that expected it to be an integer, so I figured it was better not to have it.

The cores bit did nothing, as it gets overwritten by the bit right below it that gets the number of cores with sysctl commands.

### Additional context
Also removed the bit that removes Core from CPU info, as it turned my Intel Core 2 Duo into an Intel 2 Duo.