### PR TITLE
Separate Gloire from Ironclad

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -877,9 +877,9 @@ image_source="auto"
 # DracOS, DragonFly, Drauger, Droidian, Elementary, Elive, EncryptOS, EndeavourOS, Endless, Enso,
 # EuroLinux, EvolutionOS, eweOS, Exherbo, Exodia Predator OS, Fedora, Fedora Kinoite, Fedora
 # Sericea, Fedora Silverblue, Fedora_unicode, FemboyOS, Feren, Finnix, Floflis, FreeBSD, FreeMiNT,
-# Frugalware, Funtoo, Furreto, GalliumOS, Garuda, Gentoo, GhostBSD, glaucus, gNewSense, GNOME, GNU,
-# GoboLinux, GrapheneOS, Grombyang, Guix, Haiku, HamoniKR, HarDClanZ, Hash, Huayra, Hybrid, HydroOS,
-# Hyperbola, iglunix, instantOS, Interix, IRIX, Ironclad, Itc, januslinux, Kaisen, Kali, KaOS, KDE,
+# Frugalware, Funtoo, Furreto, GalliumOS, Garuda, Gentoo, GhostBSD, glaucus, Gloire, gNewSense, GNOME,
+# GNU, GoboLinux, GrapheneOS, Grombyang, Guix, Haiku, HamoniKR, HarDClanZ, Hash, Huayra, Hybrid,
+# HydroOS, Hyperbola, iglunix, instantOS, Interix, IRIX, Itc, januslinux, Kaisen, Kali, KaOS, KDE,
 # Kibojoe, Kogaion, Korora, KrassOS, KSLinux, Kubuntu, LainOS, LangitKetujuh, LaxerOS, LEDE,
 # LibreELEC, Linspire, Linux, Linux Lite, Linux Mint, Linux Mint Old, LinuxFromScratch, Live Raizo,
 # LMDE, Lubuntu, Lunar, mac, MacaroniOS, Mageia, Magix, MagpieOS, MainsailOS, Mandriva, Manjaro,
@@ -1070,8 +1070,7 @@ get_distro() {
     [[ $distro ]] && return
 
     case $os in
-     Ironclad) distro=Ironclad ;;
-        Linux|BSD|MINIX)
+        Linux|BSD|MINIX|Ironclad)
             if [[ -f /bedrock/etc/bedrock-release && -z $BEDROCK_RESTRICT ]]; then
                 case $distro_shorthand in
                     on|tiny) distro="Bedrock Linux" ;;
@@ -1957,9 +1956,6 @@ get_kernel() {
 get_uptime() {
     # Get uptime in seconds.
     case $os in
-        Ironclad)
-            s=$(uptime -s)
-        ;;
         Linux|Windows|MINIX)
             if [[ -r /proc/uptime ]]; then
                 s=$(< /proc/uptime)
@@ -1988,7 +1984,7 @@ get_uptime() {
             s=$((now - boot))
         ;;
 
-        AIX|IRIX)
+        AIX|IRIX|Ironclad)
             t=$(LC_ALL=POSIX ps -o etime= -p 1)
 
             [[ $t == *-*   ]] && { d=${t%%-*}; t=${t#*-}; }
@@ -6634,9 +6630,9 @@ ASCII:
                                 Kinoite, Fedora Sericea, Fedora Silverblue, Fedora_unicode,
                                 FemboyOS, Feren, Finnix, Floflis, FreeBSD, FreeMiNT, Frugalware,
                                 Funtoo, Furreto, GalliumOS, Garuda, Gentoo, GhostBSD, glaucus,
-                                gNewSense, GNOME, GNU, GoboLinux, GrapheneOS, Grombyang, Guix,
-                                Haiku, HamoniKR, HarDClanZ, Hash, Huayra, Hybrid, HydroOS,
-                                Hyperbola, iglunix, instantOS, Interix, IRIX, Ironclad, Itc,
+                                Gloire, gNewSense, GNOME, GNU, GoboLinux, GrapheneOS, Grombyang,
+                                Guix, Haiku, HamoniKR, HarDClanZ, Hash, Huayra, Hybrid, HydroOS,
+                                Hyperbola, iglunix, instantOS, Interix, IRIX, Itc,
                                 januslinux, Kaisen, Kali, KaOS, KDE, Kibojoe, Kogaion, Korora,
                                 KrassOS, KSLinux, Kubuntu, LainOS, LangitKetujuh, LaxerOS, LEDE,
                                 LibreELEC, Linspire, Linux, Linux Lite, Linux Mint, Linux Mint Old,
@@ -10769,7 +10765,7 @@ ${c2}~!!7JY5PGGBBBBBBBBGGGGGGGBGGGGGP5YJ?7~~~
 EOF
         ;;
 
-         "Ironclad"*)
+         "Gloire"*)
              set_colors 5 7 0
              read -rd '' ascii_data <<'EOF'
 ${c3}


### PR DESCRIPTION
### Description
Ironclad is only a kernel, like Linux, and Gloire is an Ironclad-based operating system. Previous to this, the 2 were conflated in the neofetch script, this commit fixes that and properly separates them.

### Relevant Links
Ironclad - https://ironclad.nongnu.org
Gloire - https://github.com/Ironclad-Project/Gloire
