### PR TITLE
fix memory code for old macOS versions

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3663,13 +3663,17 @@ get_memory() {
         ;;
 
         "Mac OS X" | "macOS" | "iPhone OS")
-            hw_pagesize="$(sysctl -n hw.pagesize)"
-            mem_total="$(($(sysctl -n hw.memsize) / 1024))"
-            pages_app="$(($(sysctl -n vm.page_pageable_internal_count) - $(sysctl -n vm.page_purgeable_count)))"
-            pages_wired="$(vm_stat | awk '/ wired/ { print $4 }')"
-            pages_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
-            pages_compressed="${pages_compressed:-0}"
-            mem_used="$(((pages_app + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024))"
+            pageable="$(sysctl -n vm.page_pageable_internal_count)"
+            purgeable="$(sysctl -n vm.page_purgeable_count)"
+            if [ -n "$pageable" ] && [ -n "$purgeable" ] && type -p vm_stat &>/dev/null; then
+                hw_pagesize="$(sysctl -n hw.pagesize)"
+                mem_total="$(($(sysctl -n hw.memsize) / 1024))"
+                pages_app="$(($(sysctl -n vm.page_pageable_internal_count) - $(sysctl -n vm.page_purgeable_count)))"
+                pages_wired="$(vm_stat | awk '/ wired/ { print $4 }')"
+                pages_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
+                pages_compressed="${pages_compressed:-0}"
+                mem_used="$(((pages_app + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024))"
+            fi
         ;;
 
         "BSD" | "MINIX" | "ravynOS")

--- a/neofetch
+++ b/neofetch
@@ -3673,6 +3673,8 @@ get_memory() {
                 pages_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
                 pages_compressed="${pages_compressed:-0}"
                 mem_used="$(((pages_app + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024))"
+            else
+                return 0
             fi
         ;;
 


### PR DESCRIPTION
### Description
Fix an issue where the memory getting code would cause neofetch to fail early on old macOS versions (10.5)
It fixes it by checking that the sysctls that might not exist do, and not running the code if they don't.  It also doesn't run the code if `vm_stat` isn't present, which fixes messed up memory output on some old iOS versions.