### PR TITLE
Update Neofetch disk area Line 520

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -517,7 +517,7 @@ de_version="on"
 # NOTE: By default we only show the disk info for '/'.
 #
 # Default: '/'
-# Values:  '/', '/dev/sdXX', '/path/to/drive'.
+# Values:  '/' '/dev/sdXX' '/path/to/drive'
 # Flag:    --disk_show
 #
 # Example:


### PR DESCRIPTION
On line 520 it shows an example of how to put in what disks you want to show. it shows that you need to use ' ' and a ,  This is incorrect as the comma is not needed.


<!-- Thank you so much for contributing! ❤️ -->

### Description
Avoid confusion in the disk area

### Additional context
it suggests that you need to use the , to seperate the values. this is untrue
