### PR TITLE
Update KSLinux detection due to kpt and kpm command is removed

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1206,7 +1206,6 @@ get_distro() {
                         tiny) distro=${NAME} ;;
                         *)    distro="${NAME} ${VERSION}" ;;
                     esac
-                    echo OK
                 elif [[ -f /etc/debian_version ]] && [[ $(lsb_release -si) != *"buntu"* ]] && [[ $(lsb_release -si) != *"neon"* ]]; then
                     . /etc/os-release
                     case $distro_shorthand in

--- a/neofetch
+++ b/neofetch
@@ -1198,7 +1198,16 @@ get_distro() {
             elif type -p lsb_release >/dev/null; then
                 # Debian does not include .x versions in /etc/os-version, but does in debian_version
                 # So if that file exists, and we are not *buntu, build name from there
-                if [[ -f /etc/debian_version ]] && [[ $(lsb_release -si) != *"buntu"* ]] && [[ $(lsb_release -si) != *"neon"* ]]; then
+                if [[ $(lsb_release -si) = *"KSLinux"* ]]
+                then
+                    . /etc/os-release
+                    case $distro_shorthand in
+                        on)   distro=${NAME} ;;
+                        tiny) distro=${NAME} ;;
+                        *)    distro="${NAME} ${VERSION}" ;;
+                    esac
+                    echo OK
+                elif [[ -f /etc/debian_version ]] && [[ $(lsb_release -si) != *"buntu"* ]] && [[ $(lsb_release -si) != *"neon"* ]]; then
                     . /etc/os-release
                     case $distro_shorthand in
                         on)   distro="${NAME}" ;;
@@ -1256,10 +1265,6 @@ get_distro() {
 
             elif type -p tazpkg >/dev/null; then
                 distro="SliTaz $(< /etc/slitaz-release)"
-
-            elif type -p kpt >/dev/null && \
-                 type -p kpm >/dev/null; then
-                distro=KSLinux
 
             elif [[ -d /system/app/ && -d /system/priv-app ]]; then
                 distro="Android $(getprop ro.build.version.release)"
@@ -2237,7 +2242,6 @@ get_packages() {
             fi
 
             # Other (Needs complex command)
-            has kpm-pkg && ((packages+=$(kpm  --get-selections | grep -cv deinstall$)))
 
             nix-user-pkgs() {
                 if [ -d ~/.nix-profile ]; then


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Describe the goals that the pull request accomplishes.
Update KSLinux detection due to kpt and kpm command is removed.
KSLinux is now compactible with debian and ubuntu's ABI.

### Relevant Links
If there are related issues, please link them here.

Please also include links relevant to the changes.
[base-files packages for KSLinux](https://github.com/Yuki-Kurosawa/KSLinux_base-files)
here is the lsb-release and os-release source code.

e.g. For new distros, include a link to the distro's official website, download link, or development repository.

### Screenshots
If applicable, please include screenshots before and after your changes.
![image](https://github.com/user-attachments/assets/633b29e9-c0b1-45c5-b3d6-d47ac0611f73)


### Additional context
Add any other context about the problem or changes here.
