### PR TITLE
Update neofetch

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -5301,12 +5301,12 @@ get_local_ip() {
 
 get_public_ip() {
     if [[ -z "$public_ip_host" ]] && type -p dig >/dev/null; then
-        public_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com)"
+        public_ip="$(dig +time=1 +tries=1 +short TXT ch whoami.cloudflare @1.1.1.1 | tr -d '"')"
        [[ "$public_ip" =~ ^\; ]] && unset public_ip
     fi
 
     if [[ -z "$public_ip_host" ]] && [[ -z "$public_ip" ]] && type -p drill >/dev/null; then
-        public_ip="$(drill myip.opendns.com @resolver1.opendns.com | \
+        public_ip="$(drill whoami.cloudflare @1.1.1.1 | \
                      awk '/^myip\./ && $3 == "IN" {print $5}')"
     fi
 


### PR DESCRIPTION
### Description
Fixes the fast version of the "get_public_ip" function".

```
dig myip.opendns.com @resolver1.opendns.com
```
stopped working for me personally. but cloudflare still worked.
```
dig TXT ch whoami.cloudflare @1.1.1.1
```