### PR TITLE
🌈 Feature: Support custom ASCII art file path

### DIFF
--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -321,6 +321,18 @@ def create_config() -> Config:
     # Create config
     clear_screen(title)
     c = Config(preset, color_system, light_dark, lightness, color_alignment, backend)
+    # Ask for custom ascii art
+    print()
+    use_custom_ascii = literal_input('Do you want to use a custom ascii art file? (y/n)', ['y', 'n'], 'n')
+    if use_custom_ascii == 'y':
+        while True:
+            ascii_path = input('Enter the path to your ascii art file: ').strip()
+            if ascii_path:
+                resolved_path = str(Path(os.path.expanduser(ascii_path)).resolve())
+                if Path(resolved_path).is_file():
+                    c.custom_ascii = resolved_path
+                    break
+            print('Invalid file path. Please enter a valid path to an ascii art file.')
 
     # Save config
     print()
@@ -463,7 +475,13 @@ def run():
 
     # Run
     try:
-        asc = get_distro_ascii() if not args.ascii_file else Path(args.ascii_file).read_text("utf-8")
+        # Priority: CLI --ascii-file > config.custom_ascii > get_distro_ascii
+        if args.ascii_file:
+            asc = Path(args.ascii_file).read_text("utf-8")
+        elif config.custom_ascii and Path(config.custom_ascii).is_file():
+            asc = Path(config.custom_ascii).read_text("utf-8")
+        else:
+            asc = get_distro_ascii()
         asc = config.color_align.recolor_ascii(asc, preset)
         neofetch_util.run(asc, config.backend, config.args or '')
     except Exception as e:

--- a/hyfetch/models.py
+++ b/hyfetch/models.py
@@ -20,6 +20,13 @@ class Config:
     distro: str | None = None
     pride_month_shown: list[int] = field(default_factory=list)  # This is deprecated, see issue #136
     pride_month_disable: bool = False
+    custom_ascii: str | None = None
+
+    def get_custom_ascii_path(self) -> str | None:
+        """Return the expanded path to the custom ascii art file, or None."""
+        if self.custom_ascii:
+            return os.path.expanduser(self.custom_ascii)
+        return None
 
     @classmethod
     def from_dict(cls, d: dict):


### PR DESCRIPTION
### Description
This PR allows users to specify a custom ASCII art file path in their config or during first time setup and validates if it is a valid path. This means users no longer have to set up an alias to run the command with --ascii-file which should improve user experience. It also respects the priority of which ASCII should be loaded first (Priority: CLI --ascii-file > config.custom_ascii > get_distro_ascii).

### New config file structure
{
    "preset": "rainbow",
    "mode": "rgb",
    "light_dark": "dark",
    "lightness": 0.65,
    "color_align": {
        "mode": "horizontal",
        "custom_colors": [],
        "fore_back": null
    },
    "backend": "fastfetch",
    "args": null,
    "distro": null,
    "pride_month_shown": [],
    "pride_month_disable": false,
    "custom_ascii": "/home/theo/Documents/boykisser.txt" <--- New field
}

### Screenshots
<img width="692" height="464" alt="image" src="https://github.com/user-attachments/assets/8f0a084a-b07d-4759-b0d1-f048acb2303b" />

### Relevant Links
[Issue 104 (Custom ASCII Art)](https://github.com/hykilpikonna/hyfetch/issues/104)
