### PR TITLE
Temporary fix to GH-399

### DIFF
--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -465,6 +465,7 @@ def run():
     try:
         asc = get_distro_ascii() if not args.ascii_file else Path(args.ascii_file).read_text("utf-8")
         asc = config.color_align.recolor_ascii(asc, preset)
+        asc = '\n'.join(asc.split('\n')[1:])
         neofetch_util.run(asc, config.backend, config.args or '')
     except Exception as e:
         print(f'Error: {e}')


### PR DESCRIPTION
### Description
This fixes the issue caused by get_distro_ascii() where it adds an extra line, I have temporary moved this line later on in the code as a patch.

### Relevant Links
#399 

### Screenshots

Before:
<img width="413" height="439" alt="image" src="https://github.com/user-attachments/assets/91bec37e-0ef5-45f9-92ad-64682f5cfd2c" />

After:
<img width="396" height="427" alt="image" src="https://github.com/user-attachments/assets/c142944b-b626-4e84-9429-0320ccb2e75c" />

### Additional context
I cant seem to figure out how get_distro_ascii() is called, besides maybe from neofetch directly, so it would be great if someone could point that out to me :>