### PR TITLE
Only mark pride month easter egg as displayed when its june (rust)

### DIFF
--- a/crates/hyfetch/src/bin/hyfetch.rs
+++ b/crates/hyfetch/src/bin/hyfetch.rs
@@ -117,7 +117,7 @@ fn main() -> Result<()> {
         )
         .context("failed to write message to stdout")?;
 
-        if !june_path.is_file() {
+        if !june_path.is_file() && !options.june {
             File::create(&june_path)
                 .with_context(|| format!("failed to create file {june_path:?}"))?;
         }


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Fixing issue [402](https://github.com/hykilpikonna/hyfetch/issues/402), this issue is fixed in the python version on hyfetch however the fixes were never implemented into the rust build leading to inconsistency between the two builds. I've implemented a check into the rust version of the program to make it check if the command has been run with the --june argument and if so not update the cache. 

### Relevant Links
 [Issue 402](https://github.com/hykilpikonna/hyfetch/issues/402)
