### PR TITLE
Swap inside fstring to double quote

### DIFF
--- a/hyfetch/main.py
+++ b/hyfetch/main.py
@@ -503,7 +503,7 @@ def run():
                 print(f'Error: invalid hex color "{color}"')
         preset = ColorProfile(colors)
     else:
-        print(f'Preset should be a comma-separated list of hex colors, or one of the following: {', '.join(sorted(PRESETS.keys()))}')
+        print(f'Preset should be a comma-separated list of hex colors, or one of the following: {", ".join(sorted(PRESETS.keys()))}')
 
     if preset is None:
         exit(1)


### PR DESCRIPTION
On python 3.11 and earlier (before [PEP 701](https://docs.python.org/3.12/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings)) I get:

```
Traceback (most recent call last):
  File "/tmp/hyfetch/bin/hyfetch", line 33, in <module>
    sys.exit(load_entry_point('HyFetch==2.0.2', 'console_scripts', 'hyfetch')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/hyfetch/bin/hyfetch", line 25, in importlib_load_entry_point
    return next(matches).load()
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1128, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/tmp/hyfetch/lib/python3.11/site-packages/HyFetch-2.0.2-py3.11.egg/hyfetch/__init__.py", line 3, in <module>
    from . import main, constants
  File "/tmp/hyfetch/lib/python3.11/site-packages/HyFetch-2.0.2-py3.11.egg/hyfetch/main.py", line 506
    print(f'Preset should be a comma-separated list of hex colors, or one of the following: {', '.join(sorted(PRESETS.keys()))}')
                                                                                              ^
SyntaxError: f-string: expecting '}'
```

This fixes the issue for earlier python versions.