### PR TITLE
[F] Fix 3-length hex codes in Python when using custom preset

### DIFF
--- a/hyfetch/color_util.py
+++ b/hyfetch/color_util.py
@@ -141,9 +141,9 @@ class RGB:
             g = int(hex[2:4], 16)
             b = int(hex[4:6], 16)
         elif len(hex) == 3:
-            r = int(hex[0], 16)
-            g = int(hex[1], 16)
-            b = int(hex[2], 16)
+            r = int(hex[0] * 2, 16)
+            g = int(hex[1] * 2, 16)
+            b = int(hex[2] * 2, 16)
         else:
             raise ValueError(f"Error: invalid hex length")
         return cls(r, g, b)


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Fixes 3-length hex codes displaying incorrect colours using the custom preset in Python. Sorry for not catching this in my previous PR to add the feature.

### Relevant Links
N/A

### Screenshots
Before and after.

<img width="1549" height="716" alt="image" src="https://github.com/user-attachments/assets/61ec181a-8fc5-4a3d-be1b-b34a95b76c99" />


### Additional context
N/A
