### PR TITLE
Support iOS 1.x

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -6396,7 +6396,7 @@ cache_uname() {
                 ProductVersion)       osx_version=${sw_vers[i+1]} ;;
                 ProductBuildVersion)  osx_build=${sw_vers[i+1]}   ;;
             esac
-            # before iOS 2, iOS didn't internally make a distiction between itself and macOS,
+            # before iOS 2, iOS didn't internally distinguish between itself and macOS,
             # so we manually set the OS type if the version is 1.x
             case $osx_version in
                 1.*) darwin_name="iPhone OS" ;;


### PR DESCRIPTION
before iOS 2, iOS didn't internally distinguish between itself and macOS, so we have to manually tell neofetch that macOS 1.x is actually iOS