### PR TITLE
Added back the flags that were lost in the python and rust presets merge

### DIFF
--- a/hyfetch/data/presets.json
+++ b/hyfetch/data/presets.json
@@ -219,13 +219,13 @@
     "comment": "Sourced from https://gender.fandom.com/wiki/Fluidflux?file=FC90B24D-CA36-4FE2-A752-C9ABFC65E332.jpeg"
   },
   "fluidflux2": ["#C6D1D2", "#F47B9D", "#F09F9B", "#E3F09E", "#75EEEA", "#52D2ED", "#C6D1D2"],
+  "transbian": ["#03A3E6", "#F8B4CD","#FAFBF9", "#FA9C57", "#A80864"],
+  "autism":["#C94A49", "#DE7554", "#DBB667", "#6FA35D", "#2E7574", "#232828"],
+  "cenelian":["#FFE7B6", "#93554A", "#52203A", "#7E4A93", "#99AFD6"],
+  "transneutral":["#74DFFF", "#FFFDB3", "#FFFC75", "#FFF200", "#FFFC75", "#FFFDB3", "#FE8CBF"],
 
   "beiyang": ["#DF1B12", "#FFC600", "#01639D", "#FFFFFF", "#000000"],
   "burger": ["#F3A26A", "#498701", "#FD1C13", "#7D3829", "#F3A26A"],
   "throatlozenges": ["#2759DA", "#03940D", "#F5F100", "#F59B00", "#B71212"],
   "band": ["#2670C0", "#F5BD00", "#DC0045", "#E0608E"],
-  "transbian": ["#03A3E6", "#F8B4CD","#FAFBF9", "#FA9C57", "#A80864"],
-  "autism":["#C94A49", "#DE7554", "#DBB667", "#6FA35D", "#2E7574", "#232828"],
-  "cenelian":["#FFE7B6", "#93554A", "#52203A", "#7E4A93", "#99AFD6"],
-  "transneutral":["#74DFFF", "#FFFDB3", "#FFFC75", "#FFF200", "#FFFC75", "#FFFDB3", "#FE8CBF"]
 }


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
The current 2.0.4 version does not have the flags committed for the 2.0.3 version
as they were lost during the python and rust presets merge.
This pull adds them back in the presets.json file

### Relevant Links
[Presets Merge](https://github.com/hykilpikonna/hyfetch/commit/328381b3367ce10ed775946f6a81266abf9e8e91) Commit 328381b
(Notably missing the flags added below)
Transbian Flag: Original Commit 28a181d
Autism Flag: Original Commit bb514f8
Cenelian and Transneutral Flags: Original Commit b585ee1

### Screenshot
Before the changes (Current 2.0.4 Version)
<img width="1144" height="719" alt="Screenshot_20251118_000958" src="https://github.com/user-attachments/assets/66fee35e-bba5-4990-8c0c-2628401dd320" />

After the changes
<img width="1144" height="719" alt="Screenshot_20251117_235551" src="https://github.com/user-attachments/assets/b4344501-10be-4b32-8cbe-25550293fa22" />
<img width="1144" height="719" alt="Screenshot_20251118_001215" src="https://github.com/user-attachments/assets/443a5b28-ce21-4921-811d-bde16e0e7e67" />

