### PR TITLE
Fix shell detection by using os.execv instead of subprocess.run

### DIFF
--- a/hyfetch/rs.py
+++ b/hyfetch/rs.py
@@ -21,7 +21,7 @@ def run_rust():
         return
 
     # Run the rust executable, passing in all arguments
-    subprocess.run([str(pd)] + sys.argv[1:])
+    os.execv(str(pd), [str(pd), *sys.argv[1:]])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description

This PR fixes the issue where fastfetch shows the shell as "hyfetch" instead of the actual shell (e.g., zsh, bash) when using the fastfetch backend.

The problem occurred because `subprocess.run()` spawns a new subprocess, which causes fastfetch to detect the parent process as "hyfetch" rather than the actual shell. By replacing `subprocess.run()` with `os.execv()`, the Python process is directly replaced with the Rust binary, preserving the correct parent process chain and allowing fastfetch to properly detect the shell.

### Changes
- Replaced `subprocess.run([str(pd)] + sys.argv[1:])` with `os.execv(str(pd), [str(pd), *sys.argv[1:]])`
- This eliminates the intermediate Python wrapper process and allows proper shell detection

### Relevant Links
Fixes #445

### Testing
Tested with fastfetch backend on macOS, confirming that the shell is now correctly detected instead of showing "hyfetch".