### PR TITLE
fix neowofetch hardware detection on Interix if %WINDIR% isn't C:\Windows

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3798,12 +3798,11 @@ get_memory() {
             mem_total="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe computersystem get TotalPhysicalMemory)"
             mem_total="${mem_total//[[:space:]]}"
             mem_total="${mem_total/TotalPhysicalMemory}"
-            mem_total="$((mem_total / 1024 / 1024))"
+            mem_total="$((mem_total / 1024))"
 
             mem_free="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe os get FreePhysicalMemory)"
             mem_free="${mem_free//[[:space:]]}"
             mem_free="${mem_free/FreePhysicalMemory}"
-            mem_free="$((mem_free / 1024))"
 
             mem_used="$((mem_total - mem_free))"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1870,7 +1870,7 @@ get_model() {
         ;;
 
         Interix)
-            model="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe computersystem get manufacturer,model)"
+            model="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe computersystem get manufacturer,model)"
             model="${model/Manufacturer}"
             model="${model/Model}"
         ;;
@@ -3371,13 +3371,13 @@ END
         ;;
 
         "Interix")
-            cpu="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe cpu get Name)"
+            cpu="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe cpu get Name)"
             cpu="${cpu/Name}"
 
-            speed="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe cpu get CurrentClockSpeed)"
+            speed="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe cpu get CurrentClockSpeed)"
             speed="${speed/CurrentClockSpeed}"
 
-            cores="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe cpu get NumberOfCores)"
+            cores="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe cpu get NumberOfCores)"
             cores="${cores/NumberOfCores}"
         ;;
 
@@ -3629,7 +3629,7 @@ get_gpu() {
         ;;
 
         "Interix")
-            /dev/fs/C/Windows/System32/wbem/WMIC.exe path Win32_VideoController get caption | while read -r line; do
+            $(winpath2unix $WINDIR)/System32/wbem/WMIC.exe path Win32_VideoController get caption | while read -r line; do
                 line=$(trim "$line")
 
                 case $line in
@@ -3795,12 +3795,12 @@ get_memory() {
         ;;
 
         "Interix")
-            mem_total="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe computersystem get TotalPhysicalMemory)"
+            mem_total="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe computersystem get TotalPhysicalMemory)"
             mem_total="${mem_total//[[:space:]]}"
             mem_total="${mem_total/TotalPhysicalMemory}"
             mem_total="$((mem_total / 1024 / 1024))"
 
-            mem_free="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe os get FreePhysicalMemory)"
+            mem_free="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe os get FreePhysicalMemory)"
             mem_free="${mem_free//[[:space:]]}"
             mem_free="${mem_free/FreePhysicalMemory}"
             mem_free="$((mem_free / 1024))"
@@ -5277,10 +5277,10 @@ get_battery() {
         ;;
 
         "Interix")
-            battery="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe Path Win32_Battery get EstimatedChargeRemaining)"
+            battery="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe Path Win32_Battery get EstimatedChargeRemaining)"
             battery="${battery/EstimatedChargeRemaining}"
             battery="$(trim "$battery")%"
-            state="$(/dev/fs/C/Windows/System32/wbem/WMIC.exe /NameSpace:'\\root\WMI' Path BatteryStatus get Charging)"
+            state="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe /NameSpace:'\\root\WMI' Path BatteryStatus get Charging)"
             state="${state/Charging}"
             [[ "$state" == *TRUE* ]] && battery_state="charging"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1870,7 +1870,10 @@ get_model() {
         ;;
 
         Interix)
-            model="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe computersystem get manufacturer,model)"
+            local wmic_path
+            wmic_path="$(winpath2unix "$WINDIR")/System32/wbem/WMIC.exe"
+
+            model="$("$wmic_path" computersystem get manufacturer,model)"
             model="${model/Manufacturer}"
             model="${model/Model}"
         ;;
@@ -3371,13 +3374,16 @@ END
         ;;
 
         "Interix")
-            cpu="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe cpu get Name)"
+            local wmic_path
+            wmic_path="$(winpath2unix "$WINDIR")/System32/wbem/WMIC.exe"
+
+            cpu="$("$wmic_path" cpu get Name)"
             cpu="${cpu/Name}"
 
-            speed="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe cpu get CurrentClockSpeed)"
+            speed="$("$wmic_path" cpu get CurrentClockSpeed)"
             speed="${speed/CurrentClockSpeed}"
 
-            cores="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe cpu get NumberOfCores)"
+            cores="$("$wmic_path" cpu get NumberOfCores)"
             cores="${cores/NumberOfCores}"
         ;;
 
@@ -3629,7 +3635,10 @@ get_gpu() {
         ;;
 
         "Interix")
-            $(winpath2unix $WINDIR)/System32/wbem/WMIC.exe path Win32_VideoController get caption | while read -r line; do
+            local wmic_path
+            wmic_path="$(winpath2unix "$WINDIR")/System32/wbem/WMIC.exe"
+
+            "$wmic_path" path Win32_VideoController get caption | while read -r line; do
                 line=$(trim "$line")
 
                 case $line in
@@ -3795,12 +3804,15 @@ get_memory() {
         ;;
 
         "Interix")
-            mem_total="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe computersystem get TotalPhysicalMemory)"
+            local wmic_path
+            wmic_path="$(winpath2unix "$WINDIR")/System32/wbem/WMIC.exe"
+
+            mem_total="$("$wmic_path" computersystem get TotalPhysicalMemory)"
             mem_total="${mem_total//[[:space:]]}"
             mem_total="${mem_total/TotalPhysicalMemory}"
             mem_total="$((mem_total / 1024))"
 
-            mem_free="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe os get FreePhysicalMemory)"
+            mem_free="$("$wmic_path" os get FreePhysicalMemory)"
             mem_free="${mem_free//[[:space:]]}"
             mem_free="${mem_free/FreePhysicalMemory}"
 
@@ -5276,10 +5288,13 @@ get_battery() {
         ;;
 
         "Interix")
-            battery="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe Path Win32_Battery get EstimatedChargeRemaining)"
+            local wmic_path
+            wmic_path="$(winpath2unix "$WINDIR")/System32/wbem/WMIC.exe"
+
+            battery="$("$wmic_path" Path Win32_Battery get EstimatedChargeRemaining)"
             battery="${battery/EstimatedChargeRemaining}"
             battery="$(trim "$battery")%"
-            state="$($(winpath2unix $WINDIR)/System32/wbem/WMIC.exe /NameSpace:'\\root\WMI' Path BatteryStatus get Charging)"
+            state="$("$wmic_path" /NameSpace:'\\root\WMI' Path BatteryStatus get Charging)"
             state="${state/Charging}"
             [[ "$state" == *TRUE* ]] && battery_state="charging"
         ;;


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
this pull request does what it says in the title, in addition to fixing displaying memory for an unrelated reason

### Screenshots
before:
<img width="461" height="258" alt="image" src="https://github.com/user-attachments/assets/80322606-3b72-4a0a-aac2-1006423b4c44" />

after:
<img width="535" height="286" alt="image" src="https://github.com/user-attachments/assets/2fea5439-8e9b-445c-8bbc-55ec3408ae1e" />

### Additional context
for the memory thing, the total amount of memory is actually divided by 1024 twice and the amount of free memory is divided once, and WMIC returns them in bytes and kibibytes respectively, so those divisions would convert the amounts to mebibytes instead of kibibytes at least on Windows XP.
i'm unable to check if this issue affects Vista and 7, so i'm not sure if it does