### PR TITLE
Add demisexual flag

### DIFF
--- a/hyfetch/data/presets.json
+++ b/hyfetch/data/presets.json
@@ -39,7 +39,7 @@
   "aroace2": ["#000000", "#810081", "#A4A4A4", "#FFFFFF", "#A8D47A", "#3BA740"],
   "aroace3": ["#3BA740", "#A8D47A", "#FFFFFF", "#ABABAB", "#000000", "#A4A4A4", "#FFFFFF", "#810081"],
   "demisexual": {
-    "colors": ["#000000", "#ffffff", "#6f0071", "#d3d3d3"],
+    "colors": ["#000000", "#FFFFFF", "#6F0071", "#D3D3D3"],
     "weights": [2, 3, 1, 3],
     "comment": "sourced from https://commons.wikimedia.org/wiki/File:Demisexual_Pride_Flag.svg"
   },

--- a/hyfetch/data/presets.json
+++ b/hyfetch/data/presets.json
@@ -38,6 +38,11 @@
   },
   "aroace2": ["#000000", "#810081", "#A4A4A4", "#FFFFFF", "#A8D47A", "#3BA740"],
   "aroace3": ["#3BA740", "#A8D47A", "#FFFFFF", "#ABABAB", "#000000", "#A4A4A4", "#FFFFFF", "#810081"],
+  "demisexual": {
+    "colors": ["#000000", "#ffffff", "#6f0071", "#d3d3d3"],
+    "weights": [2, 3, 1, 3],
+    "comment": "sourced from https://commons.wikimedia.org/wiki/File:Demisexual_Pride_Flag.svg"
+  },
   "autosexual": ["#99D9EA", "#7F7F7F"],
   "intergender": {
     "colors": ["#900DC2", "#900DC2", "#FFE54F", "#900DC2", "#900DC2"],


### PR DESCRIPTION
### Description
Adds demisexual flag (#30)

### Screenshots

<img width="1638" height="811" alt="Screenshot_20260602_035614" src="https://github.com/user-attachments/assets/37266884-f61a-4bca-b023-6f0c50ceb205" />

<img width="1254" height="850" alt="Screenshot_20260602_033253" src="https://github.com/user-attachments/assets/d865b665-7458-49e1-85bb-888f541a37fb" />

### Additional context
I was showing my friend HyFetch, but unfortunately their flag (demisexual) was not listed.

I noticed that the demisexual flag got grouped into #156 for storing flags as images, but that request was last updated in 2023. This flag could be updated if the image feature is eventually desired, but in the meantime, this adds the demisexual flag using a similar color ordering to the progress flag.