### PR TITLE
Make docs more begginer friendly

### DIFF
--- a/docs/hyfetch.1
+++ b/docs/hyfetch.1
@@ -17,7 +17,7 @@ Configure hyfetch
 .TP
 \fB\-C\fR, \fB\-\-config\-file\fR=\fI\,CONFIG_FILE\/\fR
 Use another config file
-[default: "/home/azalea/.config/hyfetch.json"]
+[default: "$HOME/.config/hyfetch.json"]
 .TP
 \fB\-p\fR, \fB\-\-preset\fR=\fI\,PRESET\/\fR
 Use preset or comma\-separated color list or comma\-separated hex colors


### PR DESCRIPTION
Another option could be to use ~ like on https://github.com/hykilpikonna/hyfetch/blob/8840ac7c76fdc025afcc8fd041db1862c50b2d4e/.github/ISSUE_TEMPLATE/hf_bug.md?plain=1#L25

Assuming that /home/azalea doesn't have a special meaning