### PR TITLE
[+] Add unlabeled pride flag

### DIFF
--- a/hyfetch/data/presets.json
+++ b/hyfetch/data/presets.json
@@ -277,5 +277,8 @@
   "queervillain": {
     "colors": ["#662D91", "#8DC63F", "#F7941D", "#EC008C"],
     "comment": "Sourced from https://distressedegg.fun/qvp"
+  },
+  "unlabeled": {
+    "colors": ["#E7F9E4", "#FFFFFF", "#DEF0F7", "#FAE2C3"]
   }
 }


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description

Added the unlabeled pride flag

### Relevant Links

[https://lgbtqia.wiki/wiki/Unlabeled](https://lgbtqia.wiki/wiki/Unlabeled)

### Screenshots

<img width="1272" height="538" alt="image" src="https://github.com/user-attachments/assets/944e7a51-fa9e-40d5-bf88-7b9b86268b1b" />
