### PR TITLE
[F] Fix memory detection on macOS 27 (vm_stat gained a second "wired" line)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3996,7 +3996,7 @@ get_memory() {
                 hw_pagesize="$(sysctl -n hw.pagesize)"
                 mem_total="$(($(sysctl -n hw.memsize) / 1024))"
                 pages_app="$(($(sysctl -n vm.page_pageable_internal_count) - $(sysctl -n vm.page_purgeable_count)))"
-                pages_wired="$(vm_stat | awk '/ wired/ { print $4 }')"
+                pages_wired="$(vm_stat | awk '/Pages wired down/ { print $4 }')"
                 pages_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
                 pages_compressed="${pages_compressed:-0}"
                 mem_used="$(((pages_app + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024))"


### PR DESCRIPTION
### Description

Fixes `get_memory()` on macOS 27 (currently in beta), where neofetch/neowofetch exits 1 with no output — hyfetch surfaces it as `Error: failed to run neofetch`.

macOS 27's `vm_stat` added a new line that also contains the word `wired`:

```
Pages wired down:                             213049.
Pages tag-storage non-tag wired:                  11.
```

The pattern `/ wired/` now matches both lines, so the awk emits two tokens — the page count from the first line, plus the literal field `wired:` from the second (where the count sits in `$5`, not `$4`):

```console
$ vm_stat | awk '/ wired/ { print $4 }'
215991.
wired:
```

The `$((...))` arithmetic in `mem_used` then fails and memory detection aborts, taking the whole run down:

```
wired: + 0) * hw_pagesize / 1024: missing `)' (error token is "wired: + 0) * hw_pagesize / 1024")
```

The fix matches the full label `Pages wired down` instead. That label is the exact line the old pattern was always targeting and has been stable across macOS releases, so behavior on older versions is unchanged — only the accidental second match is excluded.

### Relevant Links

No existing issue found (searched the tracker for `vm_stat`, `wired`, and `macOS 27`).

### Screenshots

CLI change — before/after output on macOS 27 beta 3 (build 26A5378n, arm64):

```console
$ bash ./neofetch memory   # before
$ echo $?
1

$ bash ./neofetch memory   # after
memory: 10.47 GiB / 128.00 GiB (8%)
$ echo $?
0
```

### Additional context

Only this one awk site matches the new line; the `/ occupied/` pattern for compressed pages is unaffected. Older macOS versions print `Pages wired down:` as well, so no version guard is needed.
