### PR TITLE
[+] Separate lightness values for light and dark themes

### DIFF
--- a/crates/hyfetch/src/bin/hyfetch.rs
+++ b/crates/hyfetch/src/bin/hyfetch.rs
@@ -224,7 +224,8 @@ fn main() -> Result<()> {
     } else {
         color_profile.with_lightness_adaptive(
             config
-                .lightness
+                .lightness_per_theme.map(|val| val.get(theme))
+                .or(config.lightness)
                 .unwrap_or_else(|| Config::default_lightness(theme)),
             theme,
         )
@@ -1495,6 +1496,7 @@ fn create_config(
         light_dark: Some(theme),
         auto_detect_light_dark: Some(det_bg.is_some()),
         lightness: Some(lightness),
+        lightness_per_theme: None,
         color_align,
         backend,
         args: None,

--- a/crates/hyfetch/src/color_util.rs
+++ b/crates/hyfetch/src/color_util.rs
@@ -72,6 +72,13 @@ static RGB_COLORS_AC: OnceLock<AhoCorasick> = OnceLock::new();
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct Lightness(f32);
 
+/// Represents a dictionary of one lightness option per {light, dark} theme.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub struct LightnessPerTheme {
+    dark: Lightness,
+    light: Lightness,
+}
+
 #[derive(Debug, Error)]
 pub enum LightnessError {
     #[error(
@@ -145,6 +152,15 @@ impl Lightness {
         }
 
         Ok(Self(value))
+    }
+}
+
+impl LightnessPerTheme {
+    pub fn get(&self, theme: TerminalTheme) -> Lightness {
+        match theme {
+            TerminalTheme::Light => self.light,
+            TerminalTheme::Dark => self.dark
+        }
     }
 }
 

--- a/crates/hyfetch/src/models.rs
+++ b/crates/hyfetch/src/models.rs
@@ -6,6 +6,7 @@ use strum::{AsRefStr, Display, EnumString};
 
 use crate::color_profile::ColorProfile;
 use crate::color_util::Lightness;
+use crate::color_util::LightnessPerTheme;
 use crate::neofetch_util::ColorAlignment;
 use crate::types::{AnsiMode, Backend, TerminalTheme};
 
@@ -16,6 +17,7 @@ pub struct Config {
     pub auto_detect_light_dark: Option<bool>,
     pub light_dark: Option<TerminalTheme>,
     pub lightness: Option<Lightness>,
+    pub lightness_per_theme: Option<LightnessPerTheme>,
     pub color_align: ColorAlignment,
     pub backend: Backend,
     #[serde(default)]


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description

Add a `lightness_per_mode` config key accepting separate lightness values for `dark` and `light` themes.

(Note: PR also contains the same commit from #528 since I branched off my fork for that)

### Relevant Links

Closes #529.

### Screenshots

Before, with

```json
"auto_detect_light_dark": true,
"lightness": 0.85
```

<img width="226" alt="screenshot_2026-07-19_12-56-19" src="https://github.com/user-attachments/assets/517c60ef-6e34-48ad-a0a1-413a9d6d8f45" />
<img width="226" alt="screenshot_2026-07-19_12-56-29" src="https://github.com/user-attachments/assets/791b1074-e4ac-4861-87c1-844f13e66ac7" />

After, with

```json
"auto_detect_light_dark": true,
"lightness_per_theme": {
  "light": 0.85,
  "dark": 0.6
}
```

<img width="226" alt="screenshot_2026-07-19_12-55-39" src="https://github.com/user-attachments/assets/8172ac13-621d-4a87-bac2-da703fa334e1" />
<img width="226" alt="screenshot_2026-07-19_12-55-09" src="https://github.com/user-attachments/assets/42113885-2b4c-4020-960f-86c5645652ab" />

### Additional context